### PR TITLE
feat: get local ip for docker host

### DIFF
--- a/pkg/codeconfig/collect.go
+++ b/pkg/codeconfig/collect.go
@@ -3,11 +3,14 @@ package codeconfig
 import (
 	"fmt"
 	"net"
+	"os"
 	"os/exec"
 	"strings"
 
-	v1 "github.com/nitrictech/apis/go/nitric/v1"
 	"google.golang.org/grpc"
+
+	v1 "github.com/nitrictech/apis/go/nitric/v1"
+	"github.com/nitrictech/newcli/pkg/utils"
 )
 
 // Collect - Collects information about a function for a nitric stack
@@ -42,6 +45,8 @@ func Collect(ctx string, handler string, stack *Stack) error {
 	// Select an image to use based on the handler
 	var cmd *exec.Cmd = nil
 
+	var localIp = utils.GetLocalIP()
+
 	if strings.HasSuffix(handler, ".ts") {
 		cmd = exec.Command(
 			"docker",
@@ -49,7 +54,7 @@ func Collect(ctx string, handler string, stack *Stack) error {
 			"--rm",
 			// setup host.docker.internal to route to host gateway
 			// to access rpc server hosted by local CLI run
-			"--add-host", "host.docker.internal:172.17.0.1",
+			"--add-host", "host.docker.internal:"+localIp,
 			// Set the address to the bound port
 			"-e", "SERVICE_ADDRESS=host.docker.internal:50051",
 			// Set the volume mount to bound context

--- a/pkg/utils/ip.go
+++ b/pkg/utils/ip.go
@@ -1,0 +1,20 @@
+package utils
+
+import "net"
+
+// GetLocalIP returns the non loopback local IP of the host
+func GetLocalIP() string {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return ""
+	}
+	for _, address := range addrs {
+		// check the address type and if it is not a loopback the display it
+		if ipnet, ok := address.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+			if ipnet.IP.To4() != nil {
+				return ipnet.IP.String()
+			}
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
Everytime I start my WSL distro, my local IP changes and breaks the build. This fixes the issue by dynamically getting the IP each time.
I am using Windows 10 with WSL2 on a ubuntu distro.
Now this isn't required for native linux, but should still work for it. 

Thoughts please.