### PR TITLE
Fix AWS deployments.

### DIFF
--- a/pkg/provider/pulumi/aws/aws.go
+++ b/pkg/provider/pulumi/aws/aws.go
@@ -176,9 +176,9 @@ func (a *awsProvider) Deploy(ctx *pulumi.Context) error {
 		}
 	}
 
-	for k := range a.s.Apis {
+	for k, v := range a.s.ApiDocs {
 		_, err = newApiGateway(ctx, k, &ApiGatewayArgs{
-			OpenAPISpec:     a.s.ApiDocs[k],
+			OpenAPISpec:     v,
 			LambdaFunctions: funcs})
 		if err != nil {
 			return errors.WithMessage(err, "gateway "+k)

--- a/pkg/provider/pulumi/aws/gateway.go
+++ b/pkg/provider/pulumi/aws/gateway.go
@@ -71,7 +71,7 @@ func newApiGateway(ctx *pulumi.Context, name string, args *ApiGatewayArgs, opts 
 				naps[pair.name] = pair.invokeArn
 			} else {
 				// XXX: Should not occur
-				return "", fmt.Errorf("invalid data")
+				return "", fmt.Errorf("invalid data %T %v", p, p)
 			}
 		}
 

--- a/pkg/stack/function_helpers.go
+++ b/pkg/stack/function_helpers.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 )
 
-const DefaulMembraneVersion = "v0.12.1-rc.5"
+const DefaultMembraneVersion = "v0.13.0-rc.12"
 
 var _ Compute = &Function{}
 
@@ -42,7 +42,7 @@ func (f *Function) VersionString(s *Stack) string {
 	if f.Version != "" {
 		return f.Version
 	}
-	return DefaulMembraneVersion
+	return DefaultMembraneVersion
 }
 
 func (f *Function) RelativeHandlerPath(s *Stack) (string, error) {


### PR DESCRIPTION
Minor fixes for AWS deployments.

still TODO:
 - Need to do more normalization on AWS resource names e.g. remove characters like '.' from lambda names.