### PR TITLE
Print local services output

### DIFF
--- a/pkg/cmd/run/root.go
+++ b/pkg/cmd/run/root.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/nitrictech/newcli/pkg/build"
 	"github.com/nitrictech/newcli/pkg/containerengine"
+	"github.com/nitrictech/newcli/pkg/output"
 	"github.com/nitrictech/newcli/pkg/run"
 	"github.com/nitrictech/newcli/pkg/stack"
 	"github.com/nitrictech/newcli/pkg/tasklet"
@@ -95,6 +96,8 @@ var runCmd = &cobra.Command{
 			StopMsg: "Started Local Services!",
 		}
 		tasklet.MustRun(startLocalServices, tasklet.Opts{Signal: term})
+
+		output.Print(*ls.Status())
 
 		var functions []*run.Function
 

--- a/pkg/run/gateway.go
+++ b/pkg/run/gateway.go
@@ -148,9 +148,7 @@ func (s *BaseHttpGateway) Stop() error {
 
 // Create new HTTP gateway
 // XXX: No External Args for function atm (currently the plugin loader does not pass any argument information)
-func NewGateway() (gateway.GatewayService, error) {
-	address := nitric_utils.GetEnv("GATEWAY_ADDRESS", ":9001")
-
+func NewGateway(address string) (gateway.GatewayService, error) {
 	return &BaseHttpGateway{
 		address: address,
 	}, nil

--- a/pkg/run/minio.go
+++ b/pkg/run/minio.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
@@ -127,8 +126,7 @@ func (m *MinioServer) GetApiPort() int {
 }
 
 func (m *MinioServer) Stop() error {
-	defaultTimeout := time.Duration(5) * time.Second
-	return m.ce.Stop(m.cid, &defaultTimeout)
+	return m.ce.Stop(m.cid, nil)
 }
 
 func NewMinio(dir string, name string) (*MinioServer, error) {


### PR DESCRIPTION
```
     SUCCESS  Started Local Services!
    +------------------+------------------------------------------------------------------+
    | RUNNING          | true                                                             |
    | RUNDIR           | /run/user/1000/nitric/rest-api                                   |
    | GATEWAYADDRESS   | :9001                                                            |
    | MEMBRANEADDRESS  | localhost:50051                                                  |
    | MINIOCONTAINERID | 196a3cf88054b22ae740a51ade2e9aab864b3d0fc2bf54989beb3e7fd7831011 |
    | MINIOENDPOINT    | localhost:9000                                                   |
    +------------------+------------------------------------------------------------------+
    ```

Requested by @raksiv 
