### PR TITLE
feat(run): Print out the Api Endpoints

### DIFF
--- a/pkg/cmd/run/root.go
+++ b/pkg/cmd/run/root.go
@@ -122,6 +122,23 @@ var runCmd = &cobra.Command{
 
 		fmt.Println("Local running, use ctrl-C to stop")
 
+		type apiendpoint struct {
+			Api      string `yaml:"api"`
+			Endpoint string `yaml:"endpoint"`
+		}
+		apis := []apiendpoint{}
+
+		for a := range s.ApiDocs {
+			apis = append(apis, apiendpoint{Api: a, Endpoint: fmt.Sprintf("http://127.0.0.1:9001/apis/%s", a)})
+		}
+		if len(apis) == 0 {
+			// if we have a nitric.yaml then ApiDocs will be empty
+			for a := range s.Apis {
+				apis = append(apis, apiendpoint{Api: a, Endpoint: fmt.Sprintf("http://127.0.0.1:9001/apis/%s", a)})
+			}
+		}
+		output.Print(apis)
+
 		select {
 		case membraneError := <-memerr:
 			fmt.Println(errors.WithMessage(membraneError, "membrane error, exiting"))

--- a/pkg/output/format.go
+++ b/pkg/output/format.go
@@ -124,16 +124,26 @@ func printList(object interface{}, out io.Writer) {
 	tab.SetOutputMirror(out)
 
 	t := reflect.TypeOf(object)
-	tab.AppendHeader(namesFrom(t.Elem()))
+	names := namesFrom(t.Elem())
+	if len(names) > 0 {
+		tab.AppendHeader(names)
+	}
 	rows := []table.Row{}
 	v := reflect.ValueOf(object)
+
 	for i := 0; i < v.Len(); i++ {
-		if v.Index(i).Kind() == reflect.Struct {
+		switch v.Index(i).Kind() {
+		case reflect.Struct:
 			row := table.Row{}
 			for fi := 0; fi < v.Index(i).NumField(); fi++ {
 				row = append(row, v.Index(i).Field(fi))
 			}
 			rows = append(rows, row)
+		case reflect.Slice, reflect.Array, reflect.Func, reflect.Chan, reflect.Interface, reflect.Map:
+			// not yet supported
+		default:
+			// simple types
+			rows = append(rows, table.Row{v.Index(i)})
 		}
 	}
 	tab.AppendRows(rows)

--- a/pkg/run/events.go
+++ b/pkg/run/events.go
@@ -65,7 +65,7 @@ func (s *WorkerPoolEventService) Publish(topic string, event *events.NitricEvent
 		Event: evt,
 	})
 
-	fmt.Println(fmt.Sprintf("Publishing event to: %s", targets))
+	fmt.Printf("Publishing event to: %s\n", targets)
 	for _, target := range targets {
 		err = target.HandleEvent(evt)
 		if err != nil {

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -41,12 +41,10 @@ type LocalServices interface {
 }
 
 type LocalServicesStatus struct {
-	Running          bool   `yaml:"running"`
-	RunDir           string `yaml:"runDir"`
-	GatewayAddress   string `yaml:"gatewayAddress"`
-	MembraneAddress  string `yaml:"membraneAddress"`
-	MinioContainerID string `yaml:"minioContainerID"`
-	MinioEndpoint    string `yaml:"minioEndpoint"`
+	RunDir          string `yaml:"runDir"`
+	GatewayAddress  string `yaml:"gatewayAddress"`
+	MembraneAddress string `yaml:"membraneAddress"`
+	MinioEndpoint   string `yaml:"minioEndpoint"`
 }
 
 type localServices struct {
@@ -62,7 +60,6 @@ func NewLocalServices(stackName, stackPath string) LocalServices {
 		stackName: stackName,
 		stackPath: stackPath,
 		status: &LocalServicesStatus{
-			Running:         false,
 			RunDir:          path.Join(utils.NitricRunDir(), stackName),
 			GatewayAddress:  nitric_utils.GetEnv("GATEWAY_ADDRESS", ":9001"),
 			MembraneAddress: net.JoinHostPort("localhost", "50051"),
@@ -76,13 +73,12 @@ func (l *localServices) Stop() error {
 }
 
 func (l *localServices) Running() bool {
-	l.status.Running = false
 	conn, err := net.DialTimeout("tcp", net.JoinHostPort("0.0.0.0", "50051"), time.Second)
 	if err == nil && conn != nil {
 		defer conn.Close()
-		l.status.Running = true
+		return true
 	}
-	return l.status.Running
+	return false
 }
 
 func (l *localServices) Status() *LocalServicesStatus {
@@ -101,7 +97,6 @@ func (l *localServices) Start() error {
 	if err != nil {
 		return err
 	}
-	l.status.MinioContainerID = l.mio.cid
 	l.status.MinioEndpoint = fmt.Sprintf("localhost:%d", l.mio.GetApiPort())
 
 	// Connect dev storage


### PR DESCRIPTION
```
running membrane 🚀
 SUCCESS  Started Local Services!                                                                                                                                                                                                             
+-----------------+--------------------------------+
| RUNDIR          | /run/user/1000/nitric/rest-api |
| GATEWAYADDRESS  | :9001                          |
| MEMBRANEADDRESS | localhost:50051                |
| MINIOENDPOINT   | localhost:9000                 |
+-----------------+--------------------------------+
⠾ Starting Functions (1s)new Worker in pool: 1 workers available
⠽ Starting Functions (1s)new Worker in pool: 2 workers available
 SUCCESS  Started Functions!                                                                                                                                                                                                                  
Local running, use ctrl-C to stop
+--------+-----------------------------------+
| API    | ENDPOINT                          |
+--------+-----------------------------------+
| orders | http://127.0.0.1:9001/apis/orders |
+--------+-----------------------------------+
new Worker in pool: 3 workers available

```