### PR TITLE
Change x-nitric-resource-name to x-nitric-name.

### DIFF
--- a/pkg/provider/pulumi/aws/aws.go
+++ b/pkg/provider/pulumi/aws/aws.go
@@ -64,9 +64,9 @@ func (a *awsProvider) Configure(ctx context.Context, autoStack *auto.Stack) erro
 
 func commonTags(ctx *pulumi.Context, name string) pulumi.StringMap {
 	return pulumi.StringMap{
-		"x-nitric-project":       pulumi.String(ctx.Project()),
-		"x-nitric-stack":         pulumi.String(ctx.Stack()),
-		"x-nitric-resource-name": pulumi.String(name),
+		"x-nitric-project": pulumi.String(ctx.Project()),
+		"x-nitric-stack":   pulumi.String(ctx.Stack()),
+		"x-nitric-name":    pulumi.String(name),
 	}
 }
 


### PR DESCRIPTION
Currently nitrictech/nitric using the tag x-nitric-name in aws plugins for resource discovery.