### PR TITLE
feat: Allow configured default globs to be used

### DIFF
--- a/pkg/cmd/deployment/root.go
+++ b/pkg/cmd/deployment/root.go
@@ -68,15 +68,11 @@ nitric deployment apply -n prod -t aws`,
 		cobra.CheckErr(err)
 
 		s, err := stack.FromOptions(args)
-		if err != nil && len(args) > 0 {
+		cobra.CheckErr(err)
+		if !s.Loaded {
 			codeAsConfig := tasklet.Runner{
 				StartMsg: "Gathering configuration from code..",
 				Runner: func(_ output.Progress) error {
-					s, err = stack.FromOptions(args)
-					if err != nil {
-						return err
-					}
-
 					s, err = codeconfig.Populate(s)
 					return err
 				},

--- a/pkg/cmd/deployment/root.go
+++ b/pkg/cmd/deployment/root.go
@@ -52,24 +52,27 @@ var deploymentApplyCmd = &cobra.Command{
 	Use:   "apply [handlerGlob]",
 	Short: "Create or Update a new application deployment",
 	Long:  `Applies a Nitric application deployment.`,
-	Example: `nitric deployment apply
+	Example: `# use a nitric.yaml or configured default handlerGlob (stack in the current directory).
+nitric deployment apply -t aws
 
-# When using a nitric.yaml
-nitric deployment apply -n prod-aws -s ../project/ -t prod
+# use an explicit handlerGlob (stack in the current directory)
+nitric deployment apply -t aws "functions/*/*.go"
 
-# When using code-as-config, specify the functions.
-nitric deployment apply -n prod-aws -s ../project/ -t prod "functions/*.ts"
-		`,
+# use an explicit handlerGlob and explicit stack directory
+nitric deployment apply -s ../projectX -t aws "functions/*/*.go"
+
+# use a custom deployment name
+nitric deployment apply -n prod -t aws`,
 	Run: func(cmd *cobra.Command, args []string) {
 		t, err := target.FromOptions()
 		cobra.CheckErr(err)
 
-		s, err := stack.FromOptions()
+		s, err := stack.FromOptions(args)
 		if err != nil && len(args) > 0 {
 			codeAsConfig := tasklet.Runner{
 				StartMsg: "Gathering configuration from code..",
 				Runner: func(_ output.Progress) error {
-					s, err = stack.FromGlobArgs(args)
+					s, err = stack.FromOptions(args)
 					if err != nil {
 						return err
 					}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -31,9 +31,10 @@ import (
 	"github.com/nitrictech/cli/pkg/cmd/deployment"
 	"github.com/nitrictech/cli/pkg/cmd/provider"
 	"github.com/nitrictech/cli/pkg/cmd/run"
-	"github.com/nitrictech/cli/pkg/cmd/stack"
+	cmdstack "github.com/nitrictech/cli/pkg/cmd/stack"
 	cmdTarget "github.com/nitrictech/cli/pkg/cmd/target"
 	"github.com/nitrictech/cli/pkg/output"
+	"github.com/nitrictech/cli/pkg/stack"
 	"github.com/nitrictech/cli/pkg/target"
 	"github.com/nitrictech/cli/pkg/tasklet"
 	"github.com/nitrictech/cli/pkg/utils"
@@ -96,7 +97,7 @@ func init() {
 
 	rootCmd.AddCommand(deployment.RootCommand())
 	rootCmd.AddCommand(provider.RootCommand())
-	rootCmd.AddCommand(stack.RootCommand())
+	rootCmd.AddCommand(cmdstack.RootCommand())
 	rootCmd.AddCommand(cmdTarget.RootCommand())
 	rootCmd.AddCommand(run.RootCommand())
 	rootCmd.AddCommand(versionCmd)
@@ -143,6 +144,10 @@ func ensureConfigDefaults() {
 	}
 
 	if target.EnsureDefaultConfig() {
+		needsWrite = true
+	}
+
+	if stack.EnsureRuntimeDefaults() {
 		needsWrite = true
 	}
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -51,15 +51,16 @@ var rootCmd = &cobra.Command{
 	Use:   "nitric",
 	Short: "helper CLI for nitric applications",
 	Long:  ``,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if output.VerboseLevel > 1 {
+			pterm.EnableDebugMessages()
+		}
+	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	if output.VerboseLevel > 1 {
-		pterm.EnableDebugMessages()
-	}
-
 	cobra.CheckErr(rootCmd.Execute())
 }
 

--- a/pkg/cmd/run/root.go
+++ b/pkg/cmd/run/root.go
@@ -39,16 +39,20 @@ var runCmd = &cobra.Command{
 	Short: "run a nitric stack",
 	Long: `Run a nitric stack locally for development or testing
 `,
-	Example: `nitric run -s ../projectX "functions/*.ts"`,
+	Example: `# use a nitric.yaml or configured default handlerGlob (stack in the current directory).
+nitric run
+
+# use an explicit handlerGlob (stack in the current directory)
+nitric run "functions/*.ts"
+
+# use an explicit handlerGlob and explicit stack directory
+nitric run -s ../projectX/ "functions/*.ts"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		term := make(chan os.Signal, 1)
 		signal.Notify(term, os.Interrupt, syscall.SIGTERM)
 		signal.Notify(term, os.Interrupt, syscall.SIGINT)
 
-		s, err := stack.FromOptions()
-		if err != nil && len(args) > 0 {
-			s, err = stack.FromGlobArgs(args)
-		}
+		s, err := stack.FromOptions(args)
 		cobra.CheckErr(err)
 
 		ce, err := containerengine.Discover()

--- a/pkg/cmd/run/root.go
+++ b/pkg/cmd/run/root.go
@@ -111,7 +111,10 @@ nitric run -s ../projectX/ "functions/*.ts"`,
 			},
 			StopMsg: "Started Local Services!",
 		}
-		tasklet.MustRun(startLocalServices, tasklet.Opts{Signal: term})
+		tasklet.MustRun(startLocalServices, tasklet.Opts{
+			Signal:     term,
+			LogToPterm: true,
+		})
 
 		var functions []*run.Function
 

--- a/pkg/cmd/stack/root.go
+++ b/pkg/cmd/stack/root.go
@@ -120,8 +120,16 @@ var stackDescribeCmd = &cobra.Command{
 	Use:   "describe [handlerGlob]",
 	Short: "describe stack dependencies",
 	Long:  `Describes stack dependencies`,
+	Example: `# use a nitric.yaml or configured default handlerGlob (stack in the current directory).
+nitric stack describe
+
+# use an explicit handlerGlob (stack in the current directory)
+nitric stack describe "functions/*/*.go"
+
+# use an explicit handlerGlob and explicit stack directory
+nitric stack describe -s ../projectX "functions/*/*.go"`,
 	Run: func(cmd *cobra.Command, args []string) {
-		s, err := stack.FromGlobArgs(args)
+		s, err := stack.FromOptions(args)
 		cobra.CheckErr(err)
 
 		s, err = codeconfig.Populate(s)
@@ -129,7 +137,7 @@ var stackDescribeCmd = &cobra.Command{
 
 		output.Print(s)
 	},
-	Args: cobra.MinimumNArgs(1),
+	Args: cobra.MinimumNArgs(0),
 }
 
 func RootCommand() *cobra.Command {

--- a/pkg/cmd/stack/root.go
+++ b/pkg/cmd/stack/root.go
@@ -132,8 +132,10 @@ nitric stack describe -s ../projectX "functions/*/*.go"`,
 		s, err := stack.FromOptions(args)
 		cobra.CheckErr(err)
 
-		s, err = codeconfig.Populate(s)
-		cobra.CheckErr(err)
+		if !s.Loaded {
+			s, err = codeconfig.Populate(s)
+			cobra.CheckErr(err)
+		}
 
 		output.Print(s)
 	},

--- a/pkg/codeconfig/codeconfig.go
+++ b/pkg/codeconfig/codeconfig.go
@@ -447,5 +447,9 @@ func (c *codeConfig) ToStack() (*stack.Stack, error) {
 		s.Functions[f.name] = fun
 	}
 
+	if errs.Aggregate() == nil {
+		s.Loaded = true
+	}
+
 	return s, errs.Aggregate()
 }

--- a/pkg/containerengine/syslog_other.go
+++ b/pkg/containerengine/syslog_other.go
@@ -28,7 +28,6 @@ import (
 	"path"
 
 	"github.com/docker/docker/api/types/container"
-	"github.com/hashicorp/consul/sdk/freeport"
 	"gopkg.in/mcuadros/go-syslog.v2"
 
 	"github.com/nitrictech/cli/pkg/utils"
@@ -66,7 +65,7 @@ func (s *localSyslog) Config() *container.LogConfig {
 }
 
 func (s *localSyslog) Start() error {
-	ports, err := freeport.Take(1)
+	ports, err := utils.Take(1)
 	if err != nil {
 		return err
 	}

--- a/pkg/run/minio.go
+++ b/pkg/run/minio.go
@@ -25,11 +25,11 @@ import (
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/go-connections/nat"
-	"github.com/hashicorp/consul/sdk/freeport"
 	"github.com/pkg/errors"
 	"github.com/pterm/pterm"
 
 	"github.com/nitrictech/cli/pkg/containerengine"
+	"github.com/nitrictech/cli/pkg/utils"
 )
 
 type MinioServer struct {
@@ -68,7 +68,7 @@ func (m *MinioServer) Start() error {
 	//for bName := range l.s.Buckets {
 	//	os.MkdirAll(path.Join(nitricRunDir, "buckets", bName), runPerm)
 	//}
-	ports, err := freeport.Take(2)
+	ports, err := utils.Take(2)
 	if err != nil {
 		return errors.WithMessage(err, "freeport.Take")
 	}

--- a/pkg/stack/options_test.go
+++ b/pkg/stack/options_test.go
@@ -31,8 +31,9 @@ import (
 
 func newFakeStack(name, dir string) *Stack {
 	s := &Stack{
-		Name: name,
-		Dir:  dir,
+		Name:   name,
+		Dir:    dir,
+		Loaded: true,
 		Collections: map[string]Collection{
 			"dollars": {},
 		},

--- a/pkg/stack/options_test.go
+++ b/pkg/stack/options_test.go
@@ -135,7 +135,7 @@ func TestFromOptions(t *testing.T) {
 	}
 
 	stackPath = tmpDir
-	newS, err := FromOptions()
+	newS, err := FromOptions([]string{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -206,9 +206,9 @@ func TestFromGlobArgs(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			got, err := FromGlobArgs(tt.glob)
+			got, err := FromOptions(tt.glob)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("FromGlobArgs() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("FromOptions() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(want, got) {

--- a/pkg/stack/types.go
+++ b/pkg/stack/types.go
@@ -128,6 +128,7 @@ type Queue struct{}
 
 type Stack struct {
 	Dir         string                 `yaml:"-"`
+	Loaded      bool                   `yaml:"-"`
 	Name        string                 `yaml:"name"`
 	Functions   map[string]Function    `yaml:"functions,omitempty"`
 	Collections map[string]Collection  `yaml:"collections,omitempty"`
@@ -150,6 +151,7 @@ func New(name, dir string) *Stack {
 	return &Stack{
 		Name:        name,
 		Dir:         dir,
+		Loaded:      false,
 		Containers:  map[string]Container{},
 		Collections: map[string]Collection{},
 		Functions:   map[string]Function{},
@@ -296,6 +298,8 @@ func FromFile(name string) (*Stack, error) {
 
 	// Calculate default policies
 	stack.Policies = calculateDefaultPolicies(stack)
+
+	stack.Loaded = true
 
 	return stack, nil
 }

--- a/pkg/target/options.go
+++ b/pkg/target/options.go
@@ -18,15 +18,14 @@ package target
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	"github.com/nitrictech/cli/pkg/pflagext"
+	"github.com/nitrictech/cli/pkg/utils"
 )
 
 const (
@@ -46,30 +45,10 @@ var (
 	Providers   = []string{Aws, Azure, Gcp, Digitalocean}
 )
 
-func ToStringMapStringMapStringE(i interface{}) (map[string]map[string]interface{}, error) {
-	switch v := i.(type) {
-	case map[string]map[string]interface{}:
-		return v, nil
-	case map[string]interface{}:
-		var err error
-		m := make(map[string]map[string]interface{})
-
-		for k, val := range v {
-			m[k], err = cast.ToStringMapE(val)
-			if err != nil {
-				return nil, err
-			}
-		}
-		return m, nil
-	default:
-		return nil, fmt.Errorf("unable to cast %#v of type %T to map[string]map[string]interface{}", i, i)
-	}
-}
-
 func EnsureDefaultConfig() bool {
 	written := false
 
-	targets, err := ToStringMapStringMapStringE(viper.Get("targets"))
+	targets, err := utils.ToStringMapStringMapStringE(viper.Get("targets"))
 	if err != nil {
 		targets = map[string]map[string]interface{}{}
 	}
@@ -98,7 +77,7 @@ func EnsureDefaultConfig() bool {
 }
 
 func AllFromConfig() (map[string]Target, error) {
-	tsMap, err := ToStringMapStringMapStringE(viper.Get("targets"))
+	tsMap, err := utils.ToStringMapStringMapStringE(viper.Get("targets"))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/cast.go
+++ b/pkg/utils/cast.go
@@ -1,0 +1,43 @@
+// Copyright Nitric Pty Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+
+	"github.com/spf13/cast"
+)
+
+func ToStringMapStringMapStringE(i interface{}) (map[string]map[string]interface{}, error) {
+	switch v := i.(type) {
+	case map[string]map[string]interface{}:
+		return v, nil
+	case map[string]interface{}:
+		var err error
+		m := make(map[string]map[string]interface{})
+
+		for k, val := range v {
+			m[k], err = cast.ToStringMapE(val)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return m, nil
+	default:
+		return nil, fmt.Errorf("unable to cast %#v of type %T to map[string]map[string]interface{}", i, i)
+	}
+}

--- a/pkg/utils/freeport.go
+++ b/pkg/utils/freeport.go
@@ -1,0 +1,49 @@
+// Copyright Nitric Pty Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"bufio"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/consul/sdk/freeport"
+	"github.com/pterm/pterm"
+)
+
+// Take is just a wrapper around freeport.Take() that changes the
+// stderr output to pterm.Debug
+func Take(n int) ([]int, error) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+
+	stderr := os.Stderr
+	os.Stderr = w
+	ports, err := freeport.Take(n)
+	os.Stderr = stderr
+	w.Close()
+
+	in := bufio.NewScanner(r)
+	for in.Scan() {
+		pterm.Debug.Println(strings.TrimPrefix(in.Text(), "[INFO] "))
+	}
+
+	return ports, err
+}


### PR DESCRIPTION
This adds the following to the configuration:
```yaml
runtime:
  go:
    functionglob: functions/*/*.go
  ts:
    functionglob: functions/*.ts
```
Then all runtime globs get used if the user does not supply one.
Let me know if these defaults are OK.