### PR TITLE
fix: ensure config directory exists

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -137,6 +137,12 @@ func ensureConfigDefaults() {
 		tasklet.MustRun(tasklet.Runner{
 			StartMsg: "Updating configfile to include defaults",
 			Runner: func(_ tasklet.TaskletContext) error {
+				// ensure .config/nitric exists
+				err := os.MkdirAll(utils.NitricConfigDir(), os.ModePerm)
+				if err != nil {
+					return err
+				}
+
 				return viper.SafeWriteConfigAs(path.Join(utils.NitricConfigDir(), ".nitric-config.yaml"))
 			},
 			StopMsg: "Configfile updated"}, tasklet.Opts{})


### PR DESCRIPTION
Ensures the .config/nitric directory exists before writing config yaml.