### PR TITLE
fix(run): Remove any existing minio container before starting a new one

### DIFF
--- a/mocks/mock_containerengine/mock_containerengine.go
+++ b/mocks/mock_containerengine/mock_containerengine.go
@@ -199,17 +199,17 @@ func (mr *MockContainerEngineMockRecorder) NetworkCreate(arg0 interface{}) *gomo
 }
 
 // RemoveByLabel mocks base method.
-func (m *MockContainerEngine) RemoveByLabel(arg0, arg1 string) error {
+func (m *MockContainerEngine) RemoveByLabel(arg0 map[string]string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveByLabel", arg0, arg1)
+	ret := m.ctrl.Call(m, "RemoveByLabel", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RemoveByLabel indicates an expected call of RemoveByLabel.
-func (mr *MockContainerEngineMockRecorder) RemoveByLabel(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockContainerEngineMockRecorder) RemoveByLabel(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveByLabel", reflect.TypeOf((*MockContainerEngine)(nil).RemoveByLabel), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveByLabel", reflect.TypeOf((*MockContainerEngine)(nil).RemoveByLabel), arg0)
 }
 
 // Start mocks base method.

--- a/pkg/containerengine/docker.go
+++ b/pkg/containerengine/docker.go
@@ -276,12 +276,14 @@ func (d *docker) ContainersListByLabel(match map[string]string) ([]types.Contain
 	return d.cli.ContainerList(context.Background(), opts)
 }
 
-func (d *docker) RemoveByLabel(name, value string) error {
+func (d *docker) RemoveByLabel(labels map[string]string) error {
 	opts := types.ContainerListOptions{
 		All:     true,
 		Filters: filters.NewArgs(),
 	}
-	opts.Filters.Add("label", fmt.Sprintf("%s=%s", name, value))
+	for name, value := range labels {
+		opts.Filters.Add("label", fmt.Sprintf("%s=%s", name, value))
+	}
 
 	res, err := d.cli.ContainerList(context.Background(), opts)
 	if err != nil {

--- a/pkg/containerengine/podman.go
+++ b/pkg/containerengine/podman.go
@@ -121,8 +121,8 @@ func (p *podman) ContainersListByLabel(match map[string]string) ([]types.Contain
 	return p.docker.ContainersListByLabel(match)
 }
 
-func (p *podman) RemoveByLabel(name, value string) error {
-	return p.docker.RemoveByLabel(name, value)
+func (p *podman) RemoveByLabel(labels map[string]string) error {
+	return p.docker.RemoveByLabel(labels)
 }
 
 func (p *podman) ContainerExec(containerName string, cmd []string, workingDir string) error {

--- a/pkg/containerengine/types.go
+++ b/pkg/containerengine/types.go
@@ -55,7 +55,7 @@ type ContainerEngine interface {
 	ContainerWait(containerID string, condition container.WaitCondition) (<-chan container.ContainerWaitOKBody, <-chan error)
 	CopyFromArchive(nameOrID string, path string, reader io.Reader) error
 	ContainersListByLabel(match map[string]string) ([]types.Container, error)
-	RemoveByLabel(name, value string) error
+	RemoveByLabel(labels map[string]string) error
 	ContainerExec(containerName string, cmd []string, workingDir string) error
 	ContainerLogs(containerID string, opts types.ContainerLogsOptions) (io.ReadCloser, error)
 	Logger(stackPath string) ContainerLogger

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -87,7 +87,7 @@ func (l *localServices) Status() *LocalServicesStatus {
 
 func (l *localServices) Start(pool worker.WorkerPool) error {
 	var err error
-	l.mio, err = NewMinio(l.status.RunDir, "minio")
+	l.mio, err = NewMinio(l.status.RunDir, l.stackName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Steps to prevent trying to run a container that is already started:

1. change the minio container name from minio-minio to minio-[stackname]
2. Label the containers with minio and the stack name
3. use RemoveByLabel to remove these containers before starting.

fixes #80