### PR TITLE
simplify default log redirection

### DIFF
--- a/pkg/cmd/deployment/root.go
+++ b/pkg/cmd/deployment/root.go
@@ -17,6 +17,9 @@
 package deployment
 
 import (
+	"log"
+
+	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 
 	"github.com/nitrictech/cli/pkg/build"
@@ -70,6 +73,8 @@ nitric deployment apply -n prod -t aws`,
 		s, err := stack.FromOptions(args)
 		cobra.CheckErr(err)
 
+		log.SetOutput(output.NewPtermWriter(pterm.Debug))
+
 		codeAsConfig := tasklet.Runner{
 			StartMsg: "Gathering configuration from code..",
 			Runner: func(_ output.Progress) error {
@@ -78,7 +83,7 @@ nitric deployment apply -n prod -t aws`,
 			},
 			StopMsg: "Configuration gathered",
 		}
-		tasklet.MustRun(codeAsConfig, tasklet.Opts{LogToPterm: true})
+		tasklet.MustRun(codeAsConfig, tasklet.Opts{})
 
 		p, err := provider.NewProvider(s, t)
 		cobra.CheckErr(err)
@@ -90,9 +95,7 @@ nitric deployment apply -n prod -t aws`,
 			},
 			StopMsg: "Images built",
 		}
-		tasklet.MustRun(buildImages, tasklet.Opts{
-			LogToPterm: true,
-		})
+		tasklet.MustRun(buildImages, tasklet.Opts{})
 
 		deploy := tasklet.Runner{
 			StartMsg: "Deploying..",
@@ -132,7 +135,6 @@ nitric deployment delete -n prod-aws -s ../project/ -t prod
 			StopMsg: "Deployment",
 		}
 		tasklet.MustRun(deploy, tasklet.Opts{
-			LogToPterm:    true,
 			SuccessPrefix: "Deleted",
 		})
 	},

--- a/pkg/output/verbose.go
+++ b/pkg/output/verbose.go
@@ -18,6 +18,8 @@ package output
 
 import (
 	"io"
+
+	"github.com/pterm/pterm"
 )
 
 var (
@@ -41,4 +43,18 @@ func StdoutToPtermDebug(b io.ReadCloser, p Progress, prefix string) {
 		}
 		p.Debugf("%s %v", prefix, string(buf[:n]))
 	}
+}
+
+type pTermWriter struct {
+	prefix pterm.PrefixPrinter
+}
+
+func (p *pTermWriter) Write(b []byte) (n int, err error) {
+	p.prefix.Println(string(b))
+
+	return len(b), nil
+}
+
+func NewPtermWriter(prefix pterm.PrefixPrinter) *pTermWriter {
+	return &pTermWriter{prefix: prefix}
 }

--- a/pkg/tasklet/tasklet.go
+++ b/pkg/tasklet/tasklet.go
@@ -19,8 +19,6 @@ package tasklet
 import (
 	"errors"
 	"fmt"
-	"io"
-	"log"
 	"os"
 	"time"
 
@@ -42,7 +40,6 @@ type Runner struct {
 type Opts struct {
 	Signal        chan os.Signal
 	Timeout       time.Duration
-	LogToPterm    bool
 	SuccessPrefix string
 }
 
@@ -94,15 +91,6 @@ func Run(runner Runner, opts Opts) error {
 	}
 
 	tCtx := &taskletContext{spinner: spinner}
-	if opts.LogToPterm {
-		piper, pipew := io.Pipe()
-		log.SetOutput(pipew)
-		defer func() {
-			pipew.Close()
-			log.SetOutput(os.Stdout)
-		}()
-		go output.StdoutToPtermDebug(piper, tCtx, runner.StartMsg)
-	}
 
 	start := time.Now()
 	done := make(chan bool, 1)


### PR DESCRIPTION
remove LogToPterm for now and permentently redierect default logs to a pterm debug prefix writer.

I think we'll eventually want to be able to provide an io.writer to things like the membrane in future to give us more fine grain control over where we redirect log output.