### PR TITLE
fix: use filepath to get dev image path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ GOLANGCI_LINT ?= GOLANGCI_LINT_CACHE=$(GOLANGCI_LINT_CACHE) go run github.com/go
 build: generate
 	CGO_ENABLED=0 go build -o bin/nitric ./pkg/cmd/
 
+.PHONY: build-windows
+build-windows: generate
+	go build -o bin/nitric.exe ./pkg/cmd/	
+
 .PHONY: generate
 generate:
 	@go run github.com/golang/mock/mockgen github.com/nitrictech/cli/pkg/containerengine ContainerEngine > mocks/mock_containerengine/mock_containerengine.go

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -19,7 +19,7 @@ package build
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/nitrictech/cli/pkg/containerengine"
@@ -56,7 +56,7 @@ func Create(s *stack.Stack, t *target.Target) error {
 		fh.Close()
 
 		buildArgs := map[string]string{"PROVIDER": t.Provider}
-		err = cr.Build(path.Base(fh.Name()), s.Dir, f.ImageTagName(s, t.Provider), buildArgs)
+		err = cr.Build(filepath.Base(fh.Name()), s.Dir, f.ImageTagName(s, t.Provider), buildArgs)
 		if err != nil {
 			return err
 		}
@@ -64,7 +64,7 @@ func Create(s *stack.Stack, t *target.Target) error {
 
 	for _, c := range s.Containers {
 		buildArgs := map[string]string{"PROVIDER": t.Provider}
-		err := cr.Build(path.Join(s.Dir, c.Dockerfile), s.Dir, c.ImageTagName(s, t.Provider), buildArgs)
+		err := cr.Build(filepath.Join(s.Dir, c.Dockerfile), s.Dir, c.ImageTagName(s, t.Provider), buildArgs)
 		if err != nil {
 			return err
 		}
@@ -84,7 +84,7 @@ func CreateBaseDev(s *stack.Stack) error {
 		if err != nil {
 			return err
 		}
-		lang := strings.Replace(path.Ext(f.Handler), ".", "", 1)
+		lang := strings.Replace(filepath.Ext(f.Handler), ".", "", 1)
 		_, ok := imagesToBuild[lang]
 		if ok {
 			continue
@@ -104,7 +104,7 @@ func CreateBaseDev(s *stack.Stack) error {
 			return err
 		}
 
-		if err := ce.Build(path.Base(f.Name()), s.Dir, rt.DevImageName(), map[string]string{}); err != nil {
+		if err := ce.Build(filepath.Base(f.Name()), s.Dir, rt.DevImageName(), map[string]string{}); err != nil {
 			return err
 		}
 		imagesToBuild[lang] = rt.DevImageName()

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/nitrictech/cli/pkg/utils"
@@ -60,7 +60,7 @@ func NewLocalServices(stackName, stackPath string) LocalServices {
 		stackName: stackName,
 		stackPath: stackPath,
 		status: &LocalServicesStatus{
-			RunDir:          path.Join(utils.NitricRunDir(), stackName),
+			RunDir:          filepath.Join(utils.NitricRunDir(), stackName),
 			GatewayAddress:  nitric_utils.GetEnv("GATEWAY_ADDRESS", ":9001"),
 			MembraneAddress: net.JoinHostPort("localhost", "50051"),
 		},

--- a/pkg/runtime/golang.go
+++ b/pkg/runtime/golang.go
@@ -126,7 +126,7 @@ func (t *golang) LaunchOptsForFunctionCollect(runCtx string) (LaunchOpts, error)
 	return LaunchOpts{
 		Image:    t.DevImageName(),
 		TargetWD: path.Join("/go/src", module),
-		Cmd:      strslice.StrSlice{"go", "run", "./" + t.handler},
+		Cmd:      strslice.StrSlice{"go", "run", "./" + filepath.ToSlash(t.handler)},
 		Mounts: []mount.Mount{
 			{
 				Type:   "bind",

--- a/pkg/runtime/javascript.go
+++ b/pkg/runtime/javascript.go
@@ -83,7 +83,7 @@ func (t *javascript) LaunchOptsForFunctionCollect(runCtx string) (LaunchOpts, er
 	return LaunchOpts{
 		Image:      t.DevImageName(),
 		Entrypoint: strslice.StrSlice{"ts-node"},
-		Cmd:        strslice.StrSlice{"-T " + "/app/" + t.handler},
+		Cmd:        strslice.StrSlice{"-T " + "/app/" + filepath.ToSlash(t.handler)},
 		TargetWD:   "/app",
 		Mounts: []mount.Mount{
 			{

--- a/pkg/runtime/typescript.go
+++ b/pkg/runtime/typescript.go
@@ -100,7 +100,7 @@ func (t *typescript) LaunchOptsForFunctionCollect(runCtx string) (LaunchOpts, er
 	return LaunchOpts{
 		Image:      t.DevImageName(),
 		Entrypoint: strslice.StrSlice{"ts-node"},
-		Cmd:        strslice.StrSlice{"-T", "/app/" + t.handler},
+		Cmd:        strslice.StrSlice{"-T", "/app/" + filepath.ToSlash(t.handler)},
 		TargetWD:   "/app",
 		Mounts: []mount.Mount{
 			{

--- a/pkg/stack/options.go
+++ b/pkg/stack/options.go
@@ -19,7 +19,6 @@ package stack
 import (
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -126,7 +125,7 @@ func FromOptionsMinimal() (*Stack, error) {
 	if err != nil {
 		return nil, err
 	}
-	s := New(path.Base(absDir), sDir)
+	s := New(filepath.Base(absDir), sDir)
 
 	return s, nil
 }


### PR DESCRIPTION
see linked issue #91 

This also fixes issues found after the fix above. Due to path processing issues on windows due to lack of cross platform methods.

I have also tested these changes on WSL2, it works.