### PR TITLE
fix(pulumi): Produce a better message when pulumi is not installed

### DIFF
--- a/pkg/provider/pulumi/generator.go
+++ b/pkg/provider/pulumi/generator.go
@@ -19,6 +19,7 @@ package pulumi
 import (
 	"context"
 	"fmt"
+	"os/exec"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -47,6 +48,15 @@ var (
 )
 
 func New(s *stack.Stack, t *target.Target) (types.Provider, error) {
+	pv := exec.Command("pulumi", "version")
+	err := pv.Run()
+	if err != nil {
+		if strings.Contains(err.Error(), "executable file not found") {
+			return nil, errors.WithMessage(err, "Please install pulumi from https://www.pulumi.com/docs/get-started/install/")
+		}
+		return nil, err
+	}
+
 	var prov common.PulumiProvider
 	switch t.Provider {
 	case target.Aws:


### PR DESCRIPTION
Output now..
```
nitric deployment delete -t aws
Error: Please install pulumi from https://www.pulumi.com/docs/get-started/install/: exec: "pulumi": executable file not found in $PATH
```
fixes #126 