### PR TITLE
fix(target): Parsing of extra targets

### DIFF
--- a/pkg/target/options.go
+++ b/pkg/target/options.go
@@ -89,7 +89,8 @@ func AllFromConfig() (map[string]Target, error) {
 		if err != nil {
 			return nil, err
 		}
-		if len(tMap) > 3 {
+
+		if len(tMap) > 2 {
 			// Decode the "extra" map for provider specific values
 			delete(tMap, "provider")
 			delete(tMap, "region")

--- a/pkg/target/options_test.go
+++ b/pkg/target/options_test.go
@@ -80,6 +80,24 @@ func TestFromOptions(t *testing.T) {
 			},
 		},
 		{
+			name:   "from config with extra 1",
+			target: "gcp",
+			config: map[string]map[string]interface{}{
+				"gcp": {
+					"provider": "gcp",
+					"region":   "australia-southeast1",
+					"project":  "avid-life-342120",
+				},
+			},
+			want: &Target{
+				Provider: Gcp,
+				Region:   "australia-southeast1",
+				Extra: map[string]interface{}{
+					"project": "avid-life-342120",
+				},
+			},
+		},
+		{
 			name:        "from args",
 			provider:    "azure",
 			region:      "eastus",


### PR DESCRIPTION
This is needed by gcp as that target just has one extra key value pair