### PR TITLE
fix: invalid s3 action

### DIFF
--- a/pkg/provider/pulumi/aws/policy.go
+++ b/pkg/provider/pulumi/aws/policy.go
@@ -58,7 +58,6 @@ type PolicyArgs struct {
 
 var awsActionsMap map[v1.Action][]string = map[v1.Action][]string{
 	v1.Action_BucketFileList: {
-		"s3:ListBuckets",
 		"s3:GetBucketTagging",
 	},
 	v1.Action_BucketFileGet: {


### PR DESCRIPTION
This doesn't actually cause any errors, it's just a mistake. The action would be `s3:ListBucket` not `s3:ListBuckets` and we don't need it right now before we have a list feature.