### PR TITLE
feat: Improve the help

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -47,7 +47,21 @@ var (
 var rootCmd = &cobra.Command{
 	Use:   "nitric",
 	Short: "helper CLI for nitric applications",
-	Long:  ``,
+	Long: `Nitric - The fastest way to build serverless apps
+
+To begin working with Nitric, run the 'nitric new' command:
+
+    $ nitric new
+
+This will prompt you to create a new project for your cloud and language of choice.
+
+The most common commands from there are:
+
+    - nitric run   : Run a nitric stack locally for development or testing
+    - nitric up    : Deploy code to a cloud and/or update resource changes
+    - nitric down  : Tear down your stack's resources entirely from the cloud
+
+For more information, please visit the project page: https://nitric.io/docs`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		if output.VerboseLevel > 1 {
 			pterm.EnableDebugMessages()
@@ -59,24 +73,6 @@ var rootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	cobra.CheckErr(rootCmd.Execute())
-}
-
-var configHelpTopic = &cobra.Command{
-	Use:   "configuration",
-	Short: "Configuration help",
-	Long: `nitric CLI can be configured (using yaml format) in the following locations:
-${HOME}/.nitric-config.yaml
-${HOME}/.config/nitric/.nitric-config.yaml
-
-An example of the format is:
-  targets:
-    aws:
-      region: eastus
-      provider: aws
-	azure:
-	  region: eastus
-	  provider: azure
-  `,
 }
 
 func init() {
@@ -96,7 +92,6 @@ func init() {
 	rootCmd.AddCommand(cmdTarget.RootCommand())
 	rootCmd.AddCommand(run.RootCommand())
 	rootCmd.AddCommand(versionCmd)
-	rootCmd.AddCommand(configHelpTopic)
 	addAlias("stack update", "up")
 	addAlias("stack down", "down")
 	addAlias("stack list", "list")

--- a/pkg/cmd/stack/root.go
+++ b/pkg/cmd/stack/root.go
@@ -36,16 +36,18 @@ var stackName string
 
 var stackCmd = &cobra.Command{
 	Use:   "stack",
-	Short: "operate on your project in a cloud",
-	Long: `Stack command set.
+	Short: "Manage stacks",
+	Long: `Manage stacks.
+
+A stack is a named update target, and a single project may have many of them.
 
 The stack commands generally need 3 things:
 1. a target (either explicitly with "-t <targetname> or defined in the config)
-2. a stack name (either explicitly with -n <stack name> or use the default name of "dep")
-3. a stack definition, this automatically collected from the code in functions.
+2. a name (either explicitly with -n <stack name> or use the default name of "s")
+3. a project definition, this automatically collected from the code in functions.
    A glob to the functions can be a supplied by:
   - Configuration - there are default globs for each supported language in the .nitiric-config.yaml
-  - Aruments to the stack actions.
+  - Arguments to the stack actions.
 	`,
 	Example: `nitric stack up
 nitric stack down
@@ -55,15 +57,15 @@ nitric stack list
 
 var stackUpdateCmd = &cobra.Command{
 	Use:   "update [handlerGlob]",
-	Short: "Create or Update a new application stack",
-	Long:  `Updates a Nitric application stack.`,
-	Example: `# Configured default handlerGlob (stack in the current directory).
+	Short: "Deploy code to a cloud and/or update resource changes",
+	Long:  `Deploy a Nitric stack.`,
+	Example: `# Configured default handlerGlob (project in the current directory).
 nitric stack up -t aws
 
-# use an explicit handlerGlob (stack in the current directory)
+# use an explicit handlerGlob (project in the current directory)
 nitric stack up -t aws "functions/*/*.go"
 
-# use an explicit handlerGlob and explicit stack directory
+# use an explicit handlerGlob and explicit project directory
 nitric stack up -s ../projectX -t aws "functions/*/*.go"
 
 # use a custom stack name
@@ -121,11 +123,16 @@ nitric stack up -n prod -t aws`,
 
 var stackDeleteCmd = &cobra.Command{
 	Use:   "down",
-	Short: "Brings downs an application stack",
-	Long:  `Brings downs a Nitric application stack.`,
-	Example: `nitric stack down
-nitric stack down -s ../project/ -t prod
-nitric stack down -n prod-aws -s ../project/ -t prod
+	Short: "Destroy an existing stack and its resources from the cloud",
+	Long: `Destroy an existing stack and its resources
+
+This command deletes an entire existing stack by name.  After running to completion,
+all of this stack's resources and associated state will be gone.
+
+Warning: this command is generally irreversible and should be used with great care.`,
+	Example: `nitric project down
+nitric project down -s ../project/ -t prod
+nitric project down -n prod-aws -s ../project/ -t prod
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		t, err := target.FromOptions()


### PR DESCRIPTION
This is heavily borrowed from pulumi command help.

```
go run ./pkg/cmd/ help
Nitric - The fastest way to build serverless apps

To begin working with Nitric, run the 'nitric new' command:

    $ nitric new

This will prompt you to create a new project for your cloud and language of choice.

The most common commands from there are:

    - nitric run   : Run a nitric stack locally for development or testing
    - nitric up    : Deploy code to a cloud and/or update resource changes
    - nitric down  : Tear down your stack's resources entirely from the cloud

For more information, please visit the project page: https://nitric.io/docs

Usage:
  nitric [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  down        Destroy an existing stack and its resources from the cloud
  help        Help about any command
  list        list stacks for a project
  new         create a new nitric project
  run         run a nitric stack
  stack       Manage stacks
  target      work with target objects
  up          Deploy code to a cloud and/or update resource changes
  version     Print the version number of this CLI

Flags:
      --config string          config file (default is $HOME/.nitric-config.yaml)
  -h, --help                   help for nitric
  -o, --output stringEnumVar   output format (default table)
  -v, --verbose int            set the verbosity of output (larger is more verbose) (default 1)

Use "nitric [command] --help" for more information about a command.

```
fixes #142 