### PR TITLE
fix: Prevent codeAsConfig containers from clashing with running containers

### DIFF
--- a/pkg/cmd/run/root.go
+++ b/pkg/cmd/run/root.go
@@ -66,6 +66,12 @@ var runCmd = &cobra.Command{
 		}
 		tasklet.MustRun(codeAsConfig, tasklet.Opts{})
 
+		ls := run.NewLocalServices(s)
+		if ls.Running() {
+			pterm.Error.Println("Only one instance of Nitric can be run locally at a time, please check that you have ended all other instances and try again")
+			os.Exit(2)
+		}
+
 		ce, err := containerengine.Discover()
 		cobra.CheckErr(err)
 
@@ -81,9 +87,7 @@ var runCmd = &cobra.Command{
 		}
 		tasklet.MustRun(createBaseImage, tasklet.Opts{Signal: term})
 
-		ls := run.NewLocalServices(s)
 		memerr := make(chan error)
-
 		pool := run.NewRunProcessPool()
 
 		startLocalServices := tasklet.Runner{

--- a/pkg/run/function.go
+++ b/pkg/run/function.go
@@ -18,6 +18,7 @@ package run
 import (
 	"fmt"
 	goruntime "runtime"
+	"strings"
 	"time"
 
 	"github.com/docker/docker/api/types/container"
@@ -29,10 +30,11 @@ import (
 )
 
 type Function struct {
-	handler string
-	runCtx  string
-	rt      runtime.Runtime
-	ce      containerengine.ContainerEngine
+	projectName string
+	handler     string
+	runCtx      string
+	rt          runtime.Runtime
+	ce          containerengine.ContainerEngine
 	// Container id populated after a call to Start
 	cid string
 }
@@ -74,7 +76,7 @@ func (f *Function) Start() error {
 
 	pterm.Debug.Print(containerengine.Cli(cc, hc))
 
-	cID, err := f.ce.ContainerCreate(cc, hc, nil, f.Name())
+	cID, err := f.ce.ContainerCreate(cc, hc, nil, strings.Join([]string{f.projectName, "run", f.Name()}, "-"))
 	if err != nil {
 		return err
 	}
@@ -90,6 +92,7 @@ func (f *Function) Stop() error {
 }
 
 type FunctionOpts struct {
+	ProjectName     string
 	Handler         string
 	RunCtx          string
 	ContainerEngine containerengine.ContainerEngine
@@ -102,30 +105,32 @@ func newFunction(opts FunctionOpts) (*Function, error) {
 	}
 
 	return &Function{
-		rt:      rt,
-		handler: opts.Handler,
-		runCtx:  opts.RunCtx,
-		ce:      opts.ContainerEngine,
+		rt:          rt,
+		projectName: opts.ProjectName,
+		handler:     opts.Handler,
+		runCtx:      opts.RunCtx,
+		ce:          opts.ContainerEngine,
 	}, nil
 }
 
-func FunctionsFromHandlers(s *project.Project) ([]*Function, error) {
-	funcs := make([]*Function, 0, len(s.Functions))
+func FunctionsFromHandlers(p *project.Project) ([]*Function, error) {
+	funcs := make([]*Function, 0, len(p.Functions))
 	ce, err := containerengine.Discover()
 	if err != nil {
 		return nil, err
 	}
 
-	for _, f := range s.Functions {
-		relativeHandlerPath, err := f.RelativeHandlerPath(s)
+	for _, f := range p.Functions {
+		relativeHandlerPath, err := f.RelativeHandlerPath(p)
 		if err != nil {
 			return nil, err
 		}
 
 		if f, err := newFunction(FunctionOpts{
-			RunCtx:          s.Dir,
+			RunCtx:          p.Dir,
 			Handler:         relativeHandlerPath,
 			ContainerEngine: ce,
+			ProjectName:     p.Name,
 		}); err != nil {
 			return nil, err
 		} else {


### PR DESCRIPTION
- name the containers a bit better to prevent scoping issues
- start the LocalServices earlier so we can check Running() and fail earlier

Note: we can only do one "nitric run" per host. If you have different projects you still can't run it twice...
This issue with this is the port we listen on for the membrane.