### PR TITLE
cleanup: Remove stack name flag

### DIFF
--- a/pkg/cmd/stack/root.go
+++ b/pkg/cmd/stack/root.go
@@ -35,8 +35,6 @@ import (
 	"github.com/nitrictech/cli/pkg/tasklet"
 )
 
-var stackName string
-
 var stackCmd = &cobra.Command{
 	Use:   "stack",
 	Short: "Manage stacks (project deployments)",
@@ -129,7 +127,7 @@ nitric stack up -n prod -s aws`,
 		deploy := tasklet.Runner{
 			StartMsg: "Deploying..",
 			Runner: func(progress output.Progress) error {
-				d, err = p.Apply(progress, stackName)
+				d, err = p.Apply(progress, s.Name)
 				return err
 			},
 			StopMsg: "Stack",
@@ -168,7 +166,7 @@ var stackDeleteCmd = &cobra.Command{
 		deploy := tasklet.Runner{
 			StartMsg: "Deleting..",
 			Runner: func(progress output.Progress) error {
-				return p.Delete(progress, stackName)
+				return p.Delete(progress, s.Name)
 			},
 			StopMsg: "Stack",
 		}
@@ -212,11 +210,9 @@ func RootCommand() *cobra.Command {
 	stackCmd.AddCommand(newStackCmd)
 
 	stackCmd.AddCommand(stackUpdateCmd)
-	stackUpdateCmd.Flags().StringVarP(&stackName, "name", "n", "dep", "the name of the project")
 	cobra.CheckErr(stack.AddOptions(stackUpdateCmd, false))
 
 	stackCmd.AddCommand(stackDeleteCmd)
-	stackDeleteCmd.Flags().StringVarP(&stackName, "name", "n", "dep", "the name of the project")
 	cobra.CheckErr(stack.AddOptions(stackDeleteCmd, false))
 
 	stackCmd.AddCommand(stackListCmd)

--- a/pkg/cmd/stack/root.go
+++ b/pkg/cmd/stack/root.go
@@ -90,7 +90,7 @@ var stackUpdateCmd = &cobra.Command{
 # use a custom stack name
 nitric stack up -n prod -s aws`,
 	Run: func(cmd *cobra.Command, args []string) {
-		s, err := stack.FromOptions()
+		s, err := stack.ConfigFromOptions()
 		cobra.CheckErr(err)
 
 		config, err := project.ConfigFromFile()
@@ -127,7 +127,7 @@ nitric stack up -n prod -s aws`,
 		deploy := tasklet.Runner{
 			StartMsg: "Deploying..",
 			Runner: func(progress output.Progress) error {
-				d, err = p.Apply(progress, s.Name)
+				d, err = p.Up(progress)
 				return err
 			},
 			StopMsg: "Stack",
@@ -151,7 +151,7 @@ var stackDeleteCmd = &cobra.Command{
 	Example: `nitric stack down -s aws
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		s, err := stack.FromOptions()
+		s, err := stack.ConfigFromOptions()
 		cobra.CheckErr(err)
 
 		config, err := project.ConfigFromFile()
@@ -166,7 +166,7 @@ var stackDeleteCmd = &cobra.Command{
 		deploy := tasklet.Runner{
 			StartMsg: "Deleting..",
 			Runner: func(progress output.Progress) error {
-				return p.Delete(progress, s.Name)
+				return p.Down(progress)
 			},
 			StopMsg: "Stack",
 		}
@@ -185,7 +185,7 @@ var stackListCmd = &cobra.Command{
 nitric stack list -s aws
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		s, err := stack.FromOptions()
+		s, err := stack.ConfigFromOptions()
 		cobra.CheckErr(err)
 
 		config, err := project.ConfigFromFile()

--- a/pkg/provider/pulumi/aws/aws_test.go
+++ b/pkg/provider/pulumi/aws/aws_test.go
@@ -104,8 +104,8 @@ func TestAWS(t *testing.T) {
 	stackName := s.Name + "-deploy"
 
 	a := &awsProvider{
-		s: s,
-		t: &stack.Config{
+		proj: s,
+		sc: &stack.Config{
 			Provider: stack.Aws,
 			Region:   "mock",
 		},

--- a/pkg/provider/pulumi/azure/containerapp.go
+++ b/pkg/provider/pulumi/azure/containerapp.go
@@ -135,15 +135,15 @@ func (a *azureProvider) newContainerApps(ctx *pulumi.Context, name string, args 
 		return nil, err
 	}
 
-	for _, c := range a.s.Computes() {
-		localImageName := c.ImageTagName(a.s, "")
+	for _, c := range a.proj.Computes() {
+		localImageName := c.ImageTagName(a.proj, "")
 		repositoryUrl := res.Registry.LoginServer.ApplyT(func(server string) string {
-			return server + "/" + c.ImageTagName(a.s, a.t.Provider)
+			return server + "/" + c.ImageTagName(a.proj, a.sc.Provider)
 		}).(pulumi.StringOutput)
 
 		image, err := common.NewImage(ctx, c.Unit().Name+"Image", &common.ImageArgs{
 			LocalImageName:  localImageName,
-			SourceImageName: c.ImageTagName(a.s, a.t.Provider),
+			SourceImageName: c.ImageTagName(a.proj, a.sc.Provider),
 			RepositoryUrl:   repositoryUrl,
 			Username:        res.Registry.AdminUsername,
 			Password:        res.Registry.AdminPassword,

--- a/pkg/provider/pulumi/azure/mongo.go
+++ b/pkg/provider/pulumi/azure/mongo.go
@@ -48,7 +48,7 @@ func (a *azureProvider) newMongoCollections(ctx *pulumi.Context, name string, ar
 	primaryGeo := cosmosdb.AccountGeoLocationArgs{
 		FailoverPriority: pulumi.Int(0),
 		ZoneRedundant:    pulumi.Bool(false),
-		Location:         pulumi.String(a.t.Region),
+		Location:         pulumi.String(a.sc.Region),
 	}
 	secondaryGeo := cosmosdb.AccountGeoLocationArgs{
 		FailoverPriority: pulumi.Int(1),
@@ -63,7 +63,7 @@ func (a *azureProvider) newMongoCollections(ctx *pulumi.Context, name string, ar
 		ResourceGroupName:  args.ResourceGroupName,
 		Kind:               pulumi.String("MongoDB"),
 		MongoServerVersion: pulumi.String("4.0"),
-		Location:           pulumi.String(a.t.Region),
+		Location:           pulumi.String(a.sc.Region),
 		OfferType:          pulumi.String("Standard"),
 		ConsistencyPolicy: cosmosdb.AccountConsistencyPolicyArgs{
 			ConsistencyLevel: pulumi.String("Eventual"),
@@ -82,7 +82,7 @@ func (a *azureProvider) newMongoCollections(ctx *pulumi.Context, name string, ar
 		return nil, errors.WithMessage(err, "mongo db")
 	}
 
-	for k := range a.s.Collections {
+	for k := range a.proj.Collections {
 		res.Collections[k], err = cosmosdb.NewMongoCollection(ctx, resourceName(ctx, k, MongoCollectionRT), &cosmosdb.MongoCollectionArgs{
 			ResourceGroupName: args.ResourceGroupName,
 			AccountName:       res.Account.Name,

--- a/pkg/provider/pulumi/azure/storage.go
+++ b/pkg/provider/pulumi/azure/storage.go
@@ -61,7 +61,7 @@ func (a *azureProvider) newStorageResources(ctx *pulumi.Context, name string, ar
 		return nil, errors.WithMessage(err, "account create")
 	}
 
-	for bName := range a.s.Buckets {
+	for bName := range a.proj.Buckets {
 		res.Containers[bName], err = storage.NewContainer(ctx, resourceName(ctx, bName, StorageContainerRT), &storage.ContainerArgs{
 			StorageAccountName: res.Account.Name,
 		}, pulumi.Parent(res))
@@ -70,7 +70,7 @@ func (a *azureProvider) newStorageResources(ctx *pulumi.Context, name string, ar
 		}
 	}
 
-	for qName := range a.s.Queues {
+	for qName := range a.proj.Queues {
 		res.Queues[qName], err = storage.NewQueue(ctx, resourceName(ctx, qName, StorageQueueRT), &storage.QueueArgs{
 			StorageAccountName: res.Account.Name,
 		}, pulumi.Parent(res))

--- a/pkg/provider/pulumi/gcp/cloudrunner.go
+++ b/pkg/provider/pulumi/gcp/cloudrunner.go
@@ -91,7 +91,7 @@ func (g *gcpProvider) newCloudRunner(ctx *pulumi.Context, name string, args *Clo
 	maxScale := common.IntValueOrDefault(args.Compute.Unit().MaxScale, 10)
 	minScale := common.IntValueOrDefault(args.Compute.Unit().MinScale, 0)
 	res.Service, err = cloudrun.NewService(ctx, name, &cloudrun.ServiceArgs{
-		Location: pulumi.String(g.t.Region),
+		Location: pulumi.String(g.sc.Region),
 		Project:  pulumi.String(args.ProjectId),
 		Template: cloudrun.ServiceTemplateArgs{
 			Metadata: cloudrun.ServiceTemplateMetadataArgs{

--- a/pkg/provider/pulumi/gcp/gcp_test.go
+++ b/pkg/provider/pulumi/gcp/gcp_test.go
@@ -94,8 +94,8 @@ func TestGCP(t *testing.T) {
 	stackName := s.Name + "-deploy"
 
 	a := &gcpProvider{
-		s: s,
-		t: &stack.Config{
+		proj: s,
+		sc: &stack.Config{
 			Provider: stack.Aws,
 			Region:   "mock",
 		},

--- a/pkg/provider/pulumi/generator.go
+++ b/pkg/provider/pulumi/generator.go
@@ -39,16 +39,16 @@ import (
 )
 
 type pulumiDeployment struct {
-	s *project.Project
-	t *stack.Config
-	p common.PulumiProvider
+	proj *project.Project
+	sc   *stack.Config
+	prov common.PulumiProvider
 }
 
 var (
 	_ types.Provider = &pulumiDeployment{}
 )
 
-func New(s *project.Project, t *stack.Config) (types.Provider, error) {
+func New(p *project.Project, sc *stack.Config) (types.Provider, error) {
 	pv := exec.Command("pulumi", "version")
 	err := pv.Run()
 	if err != nil {
@@ -59,50 +59,48 @@ func New(s *project.Project, t *stack.Config) (types.Provider, error) {
 	}
 
 	var prov common.PulumiProvider
-	switch t.Provider {
+	switch sc.Provider {
 	case stack.Aws:
-		prov = aws.New(s, t)
+		prov = aws.New(p, sc)
 	case stack.Azure:
-		prov = azure.New(s, t)
+		prov = azure.New(p, sc)
 	case stack.Gcp:
-		prov = gcp.New(s, t)
+		prov = gcp.New(p, sc)
 	default:
-		return nil, utils.NewNotSupportedErr("pulumi provider " + t.Provider + " not suppored")
+		return nil, utils.NewNotSupportedErr("pulumi provider " + sc.Provider + " not suppored")
 	}
 
-	/*TODO check
-	if err := prov.Validate(); err != nil {
-		return nil, err
-	}
-	*/
 	return &pulumiDeployment{
-		s: s,
-		t: t,
-		p: prov,
+		proj: p,
+		sc:   sc,
+		prov: prov,
 	}, nil
 }
 
 func (p *pulumiDeployment) Ask() (*stack.Config, error) {
-	return p.p.Ask()
+	return p.prov.Ask()
 }
 
 func (p *pulumiDeployment) load(log output.Progress) (*auto.Stack, error) {
-	projectName := p.s.Name
-	stackName := p.s.Name + "-" + p.t.Name
+	if err := p.prov.Validate(); err != nil {
+		return nil, err
+	}
+
+	stackName := p.proj.Name + "-" + p.sc.Name
 	ctx := context.Background()
 
-	s, err := auto.UpsertStackInlineSource(ctx, stackName, projectName, p.p.Deploy,
+	s, err := auto.UpsertStackInlineSource(ctx, stackName, p.proj.Name, p.prov.Deploy,
 		auto.SecretsProvider("passphrase"),
 		auto.Project(workspace.Project{
-			Name:    tokens.PackageName(projectName),
+			Name:    tokens.PackageName(p.proj.Name),
 			Runtime: workspace.NewProjectRuntimeInfo("go", nil),
-			Main:    p.s.Dir,
+			Main:    p.proj.Dir,
 		}))
 	if err != nil {
 		return nil, errors.WithMessage(err, "UpsertStackInlineSource")
 	}
 
-	for _, plug := range p.p.Plugins() {
+	for _, plug := range p.prov.Plugins() {
 		log.Busyf("Installing Pulumi plugin %s:%s", plug.Name, plug.Version)
 		err = s.Workspace().InstallPlugin(ctx, plug.Name, plug.Version)
 		if err != nil {
@@ -110,7 +108,7 @@ func (p *pulumiDeployment) load(log output.Progress) (*auto.Stack, error) {
 		}
 	}
 
-	err = p.p.Configure(ctx, &s)
+	err = p.prov.Configure(ctx, &s)
 	if err != nil {
 		return nil, errors.WithMessage(err, "Configure")
 	}
@@ -127,7 +125,7 @@ func (p *pulumiDeployment) Up(log output.Progress) (*types.Deployment, error) {
 	}
 
 	res, err := s.Up(context.Background(), updateLoggingOpts(log)...)
-	defer p.p.CleanUp()
+	defer p.prov.CleanUp()
 	if err != nil {
 		return nil, errors.WithMessage(err, "Updating pulumi stack "+res.Summary.Message)
 	}
@@ -145,14 +143,14 @@ func (p *pulumiDeployment) Up(log output.Progress) (*types.Deployment, error) {
 }
 
 func (p *pulumiDeployment) List() (interface{}, error) {
-	projectName := p.s.Name
+	projectName := p.proj.Name
 
 	ws, err := auto.NewLocalWorkspace(context.Background(),
 		auto.SecretsProvider("passphrase"),
 		auto.Project(workspace.Project{
 			Name:    tokens.PackageName(projectName),
 			Runtime: workspace.NewProjectRuntimeInfo("go", nil),
-			Main:    p.s.Dir,
+			Main:    p.proj.Dir,
 		}))
 	if err != nil {
 		return nil, errors.WithMessage(err, "UpsertStackInlineSource")

--- a/pkg/provider/pulumi/generator.go
+++ b/pkg/provider/pulumi/generator.go
@@ -86,9 +86,9 @@ func (p *pulumiDeployment) Ask() (*stack.Config, error) {
 	return p.p.Ask()
 }
 
-func (p *pulumiDeployment) load(log output.Progress, name string) (*auto.Stack, error) {
+func (p *pulumiDeployment) load(log output.Progress) (*auto.Stack, error) {
 	projectName := p.s.Name
-	stackName := p.s.Name + "-" + name
+	stackName := p.s.Name + "-" + p.t.Name
 	ctx := context.Background()
 
 	s, err := auto.UpsertStackInlineSource(ctx, stackName, projectName, p.p.Deploy,
@@ -120,8 +120,8 @@ func (p *pulumiDeployment) load(log output.Progress, name string) (*auto.Stack, 
 	return &s, errors.WithMessage(err, "Refresh")
 }
 
-func (p *pulumiDeployment) Apply(log output.Progress, name string) (*types.Deployment, error) {
-	s, err := p.load(log, name)
+func (p *pulumiDeployment) Up(log output.Progress) (*types.Deployment, error) {
+	s, err := p.load(log)
 	if err != nil {
 		return nil, errors.WithMessage(err, "loading pulumi stack")
 	}
@@ -161,8 +161,8 @@ func (p *pulumiDeployment) List() (interface{}, error) {
 	return ws.ListStacks(context.Background())
 }
 
-func (a *pulumiDeployment) Delete(log output.Progress, name string) error {
-	s, err := a.load(log, name)
+func (a *pulumiDeployment) Down(log output.Progress) error {
+	s, err := a.load(log)
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/types/interface.go
+++ b/pkg/provider/types/interface.go
@@ -26,8 +26,8 @@ type Deployment struct {
 }
 
 type Provider interface {
-	Apply(log output.Progress, deploymentName string) (*Deployment, error)
-	Delete(log output.Progress, deploymentName string) error
+	Up(log output.Progress) (*Deployment, error)
+	Down(log output.Progress) error
 	List() (interface{}, error)
 	Ask() (*stack.Config, error)
 	//Status()

--- a/pkg/stack/data/nitric-x.yaml
+++ b/pkg/stack/data/nitric-x.yaml
@@ -1,0 +1,5 @@
+name: zed
+provider: Azure
+region: eastus2
+adminemail: admin@example.com
+org: example.com

--- a/pkg/stack/options_test.go
+++ b/pkg/stack/options_test.go
@@ -16,18 +16,27 @@
 
 package stack
 
-const (
-	Aws          = "aws"
-	Azure        = "azure"
-	Gcp          = "gcp"
-	Digitalocean = "digitalocean"
+import (
+	"reflect"
+	"testing"
 )
 
-var Providers = []string{Aws, Azure, Gcp, Digitalocean}
-
-type Config struct {
-	Name     string                 `yaml:"name,omitempty"`
-	Provider string                 `yaml:"provider,omitempty"`
-	Region   string                 `yaml:"region,omitempty"`
-	Extra    map[string]interface{} `yaml:",inline,omitempty"`
+func Test_configFromFile(t *testing.T) {
+	want := &Config{
+		Name:     "zed",
+		Provider: "Azure",
+		Region:   "eastus2",
+		Extra: map[string]interface{}{
+			"adminemail": "admin@example.com",
+			"org":        "example.com",
+		},
+	}
+	got, err := configFromFile("data/nitric-x.yaml")
+	if err != nil {
+		t.Errorf("configFromFile() error = %v", err)
+		return
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("configFromFile() = %v, want %v", got, want)
+	}
 }


### PR DESCRIPTION
This is just some cleanup from the command changes and renaming of types.

- remove the stackName flag as you can now configure it in the stack file
- rename member variables to better suit their type names
- rename the provider functions to better match the command names
