### PR TITLE
docs: refresh readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ generate:
 	@go run ./hack/modversion "github.com/pulumi/pulumi-azure/" > pkg/provider/pulumi/azure/pulumi-azure-version.txt
 	@go run ./hack/modversion "github.com/pulumi/pulumi-azure-native/" > pkg/provider/pulumi/azure/pulumi-azure-native-version.txt
 	@go run ./hack/modversion "github.com/pulumi/pulumi-aws/" > pkg/provider/pulumi/aws/pulumi-aws-version.txt
-
+	@go run ./hack/readmegen/ README.md
 
 .PHONY: fmt
 fmt:

--- a/README.md
+++ b/README.md
@@ -1,28 +1,53 @@
 # Nitric CLI
+
 ![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/nitrictech/cli/Tests/develop?label=tests)
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/nitrictech/cli)
 ![GitHub all releases](https://img.shields.io/github/downloads/nitrictech/cli/total)
 
-
 ## Overview
 
-Nitric provides a command-line interface (CLI) to assist with various tasks when building applications with [Nitric](https://nitric.io). To view a list of available commands, you can call the CLI without specifying any subcommands or arguments:
+Nitric provides a command-line interface (CLI) to assist with various tasks when building applications with the Nitric framework. For more information, check out the main [Nitric repo](https://github.com/nitrictech/nitric).
+
+## Installation
+
+The Nitric CLI is free to [download and install](https://nitric.io/docs/installation).
+
+## Purpose
+
+The Nitric CLI performs 3 main tasks:
+
+- Create new projects
+- Run apps locally for testing and development
+- Deploy to the cloud you choose
+
+## Common Commands
+
+Common commands in the CLI that you’ll be using:
+…..
+
+## Help with Commands
+
+Each command is self documented and provides a "help" interface describing the usage, arguments and options for the command. Use the help command to view the help information for any other command:
+
+Example displaying help for the `new` command
 
 ```bash
-nitric
+nitric new --help
 ```
 
-### Help and Documentation
+## Complete Reference
 
-Each command is self documented and provides a "help" interface describing the usage, arguments and options for the command. Use the `help` command to view the help information for any other command:
+Documentation for all available commands:
+……
 
-```bash
-# Example displaying help for the `stack up` command
-nitric help stack up
-```
+## Get in touch
 
-### Bash Completion
+- Ask questions in [GitHub discussions](https://github.com/nitrictech/nitric/discussions)
 
-```bash
-eval "$(nitric completion bash)"
-```
+- Find us on [Twitter](https://twitter.com/nitric_io)
+
+- Send us an [email](mailto:maintainers@nitric.io)
+
+## Get Started
+
+Check out the [Nitric docs](https://nitric.io/docs) to see how to get started using Nitric.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ The Nitric CLI performs 3 main tasks:
 ## Common Commands
 
 Common commands in the CLI that you’ll be using:
-…..
+
+- nitric down            : Undeploy a previously deployed stack, deleting resources
+- nitric run             : Run your project locally for development and testing
+- nitric stack new       : Create a new Nitric stack
+- nitric up              : Create or update a deployed stack
 
 ## Help with Commands
 
@@ -38,7 +42,18 @@ nitric new --help
 ## Complete Reference
 
 Documentation for all available commands:
-……
+
+- nitric new [projectName] [templateName] [handlerGlob] : Create a new project
+- nitric run             : Run your project locally for development and testing
+- nitric stack           : Manage stacks (the deployed app containing multiple resources e.g. collection, bucket, topic)
+- nitric stack down [-s stack] : Undeploy a previously deployed stack, deleting resources
+  (alias: nitric down)
+- nitric stack list [-s stack] : List all project stacks and their status
+  (alias: nitric list)
+- nitric stack new       : Create a new Nitric stack
+- nitric stack update [-s stack] : Create or update a deployed stack
+  (alias: nitric up)
+- nitric version         : Print the version number of this CLI
 
 ## Get in touch
 
@@ -51,3 +66,4 @@ Documentation for all available commands:
 ## Get Started
 
 Check out the [Nitric docs](https://nitric.io/docs) to see how to get started using Nitric.
+cs](https://nitric.io/docs) to see how to get started using Nitric.

--- a/hack/readmegen/main.go
+++ b/hack/readmegen/main.go
@@ -1,0 +1,111 @@
+// Copyright Nitric Pty Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"log"
+	"os"
+
+	"github.com/nitrictech/cli/pkg/cmd"
+)
+
+type section struct {
+	startLine string
+	genFunc   func(*section) []string
+	endLine   string
+}
+
+var sections = map[string]*section{
+	"common": {
+		startLine: "## Common Commands",
+		genFunc:   generatedCommonCommands,
+		endLine:   "## Help with Commands",
+	},
+	"complete": {
+		startLine: "## Complete Reference",
+		genFunc:   generatedCompleteCommands,
+		endLine:   "## Get in touch",
+	},
+}
+
+func generatedCommonCommands(s *section) []string {
+	return cmd.CommonCommandsUsage()
+}
+
+func generatedCompleteCommands(s *section) []string {
+	return cmd.AllCommandsUsage()
+}
+
+func readmeContent(readmePath string) ([]string, error) {
+	file, err := os.Open(readmePath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	output := []string{}
+	var inSection *section
+	for scanner.Scan() {
+		if inSection == nil {
+			for k, v := range sections {
+				if v.startLine == scanner.Text() {
+					inSection = sections[k]
+					delete(sections, k)
+					output = append(output, scanner.Text())
+					output = append(output, inSection.genFunc(v)...)
+					break
+				}
+			}
+		}
+		if inSection != nil {
+			if scanner.Text() == inSection.endLine {
+				inSection = nil
+			}
+		}
+		if inSection == nil {
+			output = append(output, scanner.Text())
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return output, nil
+}
+
+func main() {
+	readmePath := os.Args[1]
+	output, err := readmeContent(readmePath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	file, err := os.OpenFile(readmePath, os.O_RDWR, 0)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer file.Close()
+
+	for _, line := range output {
+		_, err = file.WriteString(line + "\n")
+		if err != nil {
+			log.Print(err)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -16,6 +16,8 @@
 
 package main
 
+import "github.com/nitrictech/cli/pkg/cmd"
+
 func main() {
-	Execute()
+	cmd.Execute()
 }

--- a/pkg/cmd/newproject.go
+++ b/pkg/cmd/newproject.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"errors"

--- a/pkg/cmd/run/root.go
+++ b/pkg/cmd/run/root.go
@@ -39,10 +39,11 @@ import (
 )
 
 var runCmd = &cobra.Command{
-	Use:     "run",
-	Short:   "Run your project locally for development and testing",
-	Long:    `Run your project locally for development and testing`,
-	Example: `nitric run`,
+	Use:         "run",
+	Short:       "Run your project locally for development and testing",
+	Long:        `Run your project locally for development and testing`,
+	Example:     `nitric run`,
+	Annotations: map[string]string{"commonCommand": "yes"},
 	Run: func(cmd *cobra.Command, args []string) {
 		term := make(chan os.Signal, 1)
 		signal.Notify(term, os.Interrupt, syscall.SIGTERM)

--- a/pkg/cmd/stack/root.go
+++ b/pkg/cmd/stack/root.go
@@ -42,8 +42,8 @@ var (
 
 var stackCmd = &cobra.Command{
 	Use:   "stack",
-	Short: "Manage stacks (project deployments)",
-	Long: `Manage stacks (project deployments).
+	Short: "Manage stacks (the deployed app containing multiple resources e.g. collection, bucket, topic)",
+	Long: `Manage stacks (the deployed app containing multiple resources e.g. collection, bucket, topic).
 
 A stack is a named update target, and a single project may have many of them.`,
 	Example: `nitric stack up
@@ -54,7 +54,7 @@ nitric stack list
 
 var newStackCmd = &cobra.Command{
 	Use:   "new",
-	Short: "create a new nitric stack",
+	Short: "Create a new Nitric stack",
 	Long:  `Creates a new Nitric stack.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		name := ""
@@ -83,17 +83,15 @@ var newStackCmd = &cobra.Command{
 		err = sc.ToFile(filepath.Join(pc.Dir, fmt.Sprintf("nitric-%s.yaml", sc.Name)))
 		cobra.CheckErr(err)
 	},
-	Args: cobra.MaximumNArgs(2),
+	Args:        cobra.MaximumNArgs(2),
+	Annotations: map[string]string{"commonCommand": "yes"},
 }
 
 var stackUpdateCmd = &cobra.Command{
-	Use:   "update",
-	Short: "Create or update a deployed stack",
-	Long:  `Create or update a deployed stack`,
-	Example: `nitric stack up -s aws
-
-# use a custom stack name
-nitric stack up -n prod -s aws`,
+	Use:     "update [-s stack]",
+	Short:   "Create or update a deployed stack",
+	Long:    `Create or update a deployed stack`,
+	Example: `nitric stack update -s aws`,
 	Run: func(cmd *cobra.Command, args []string) {
 		s, err := stack.ConfigFromOptions()
 		cobra.CheckErr(err)
@@ -150,7 +148,7 @@ nitric stack up -n prod -s aws`,
 }
 
 var stackDeleteCmd = &cobra.Command{
-	Use:   "down",
+	Use:   "down [-s stack]",
 	Short: "Undeploy a previously deployed stack, deleting resources",
 	Long:  `Undeploy a previously deployed stack, deleting resources`,
 	Example: `nitric stack down -s aws
@@ -199,10 +197,10 @@ nitric stack down -e aws -y`,
 }
 
 var stackListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   "list [-s stack]",
 	Short: "List all project stacks and their status",
 	Long:  `List all project stacks and their status`,
-	Example: `nitric list
+	Example: `nitric stack list
 
 nitric stack list -s aws
 `,

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
 	"fmt"


### PR DESCRIPTION
commit b552b4e05db6b06ccf99334176e981ffb61a31cf
Author: Angus Salkeld
Date:   Tue Mar 8 14:37:11 2022 +1000

    docs: auto generate the command help section of the readme
    
    closes nitrictech/nitric-website#320

commit 25bd6a5343bf5e50cb7ca832baf976108439aabc
Author: Rak
Date:   Thu Mar 3 14:49:20 2022 -0700

    wip: skeleton for new CLI Readme

```
go run ./main.go help
Nitric - The fastest way to build serverless apps

To start with nitric, run the 'nitric new' command:

    $ nitric new

This will guide you through project creation, including selecting from available templates.

Common commands in the CLI that you’ll be using:

- nitric down            : Undeploy a previously deployed stack, deleting resources
- nitric run             : Run your project locally for development and testing
- nitric stack new       : Create a new Nitric stack
- nitric up              : Create or update a deployed stack

For further details visit our docs https://nitric.io/docs

Usage:
  nitric [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  down        Undeploy a previously deployed stack, deleting resources
  help        Help about any command
  list        List all project stacks and their status
  new         Create a new project
  run         Run your project locally for development and testing
  stack       Manage stacks (the deployed app containing multiple resources e.g. collection, bucket, topic)
  up          Create or update a deployed stack
  version     Print the version number of this CLI

Flags:
  -h, --help                   help for nitric
  -o, --output stringEnumVar   output format (default table)
  -v, --verbose int            set the verbosity of output (larger is more verbose) (default 1)

Use "nitric [command] --help" for more information about a command.
```