### PR TITLE
feat: Catch panics and print a issue link for users to report bugs

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/nitrictech/cli/pkg/cmd/run"
 	cmdstack "github.com/nitrictech/cli/pkg/cmd/stack"
+	"github.com/nitrictech/cli/pkg/ghissue"
 	"github.com/nitrictech/cli/pkg/output"
 )
 
@@ -57,6 +58,13 @@ var rootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	defer func() {
+		if err := recover(); err != nil {
+			pterm.Error.Println("An unexpected error occurred, please create a github issue by clicking on the link below")
+			fmt.Println(ghissue.BugLink(err))
+		}
+	}()
+
 	cobra.CheckErr(rootCmd.Execute())
 }
 

--- a/pkg/ghissue/buglink.go
+++ b/pkg/ghissue/buglink.go
@@ -1,0 +1,72 @@
+// Copyright Nitric Pty Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ghissue
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"runtime"
+	"runtime/debug"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/nitrictech/cli/pkg/utils"
+)
+
+type Diagnostics struct {
+	OS         string `json:"os"`
+	Arch       string `json:"arch"`
+	GoVersion  string `json:"goVersion"`
+	CliVersion string `json:"cliVersion"`
+}
+
+type GHIssue struct {
+	Diagnostics Diagnostics `json:"diagnostics"`
+	Command     string      `json:"command"`
+	Error       string      `json:"error"`
+	StackTrace  string      `json:"stacktrace"`
+}
+
+var diag = Diagnostics{
+	OS:         runtime.GOOS,
+	Arch:       runtime.GOARCH,
+	GoVersion:  runtime.Version(),
+	CliVersion: utils.Version,
+}
+
+func BugLink(err interface{}) string {
+	issue := GHIssue{
+		Diagnostics: diag,
+		Error:       fmt.Sprint(err),
+		StackTrace:  string(debug.Stack()),
+		Command:     strings.Join(os.Args, " "),
+	}
+
+	title := "Command '" + issue.Command + "' panicked: " + utils.StringTrunc(issue.Error, 50)
+	b, _ := yaml.Marshal(issue)
+
+	issueUrl, _ := url.Parse("https://github.com/nitrictech/cli/issues/new")
+
+	q := issueUrl.Query()
+	q.Add("title", title)
+	q.Add("body", string(b))
+	issueUrl.RawQuery = q.Encode()
+
+	return issueUrl.String()
+}

--- a/pkg/ghissue/buglink_test.go
+++ b/pkg/ghissue/buglink_test.go
@@ -1,0 +1,52 @@
+// Copyright Nitric Pty Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ghissue
+
+import (
+	"net/url"
+	"os"
+	"testing"
+)
+
+func TestBugLink(t *testing.T) {
+	origArgs := os.Args
+	os.Args = []string{"test"}
+	got := BugLink("oops, I did it again!")
+	os.Args = origArgs
+
+	gotUrl, err := url.Parse(got)
+	if err != nil {
+		t.Errorf("BugLink() ulr error = %v", err)
+	}
+
+	wantHost := "github.com"
+	if gotUrl.Host != wantHost {
+		t.Errorf("BugLink() host = %v, want %v", gotUrl.Host, wantHost)
+	}
+
+	wantPath := "/nitrictech/cli/issues/new"
+	if gotUrl.Path != wantPath {
+		t.Errorf("BugLink() path = %v, want %v", gotUrl.Path, wantPath)
+	}
+
+	gotQ := gotUrl.Query()
+
+	wantTitle := "Command 'test' panicked: oops, I did it again!"
+	if gotQ["title"][0] != wantTitle {
+		t.Errorf("BugLink() title = %v, want %v", gotQ["title"][0], wantTitle)
+	}
+}


### PR DESCRIPTION
When any command panics, catch the error and print a URL that the user can use to create a github bug issue.

Here is an example:

nitric list
  ERROR   An unexpected error occurred, please create a github issue by clicking on the link below
https://github.com/nitrictech/cli/issues/new?body=diagnostics%3A%0A++os%3A+linux%0A++arch%3A+amd64%0A++goversion%3A+go1.17.7%0A++cliversion%3A+v1.1.0-develop.14-42-g48aacf42a53389ae62b48616ecdf7864acb451c2-dirty%0Acommand%3A+nitric+stack+list%0Aerror%3A+%27runtime+error%3A+invalid+memory+address+or+nil+pointer+dereference%27%0Astacktrace%3A+%22goroutine+1+%5Brunning%5D%3A%5Cnruntime%2Fdebug.Stack%28%29%5Cn%5Ct%2Fhome%2Fangus%2F.gvm%2Fgos%2Fgo1.17.7%2Fsrc%2Fruntime%2Fdebug%2Fstack.go%3A24%0A++%2B0x65%5Cngithub.com%2Fnitrictech%2Fcli%2Fpkg%2Fghissue.BugLink%28%7B0x21e8d80%2C+0x4e12640%7D%29%5Cn%5Ct%2Fhome%2Fangus%2Fcode%2Fgo%2Fsrc%2Fgithub.com%2Fnitrictech%2Fcli%2Fpkg%2Fghissue%2Fbuglink.go%3A57%0A++%2B0x79%5Cnmain.Execute.func1%28%29%5Cn%5Ct%2Fhome%2Fangus%2Fcode%2Fgo%2Fsrc%2Fgithub.com%2Fnitrictech%2Fcli%2Fpkg%2Fcmd%2Froot.go%3A72%0A++%2B0x7e%5Cnpanic%28%7B0x21e8d80%2C+0x4e12640%7D%29%5Cn%5Ct%2Fhome%2Fangus%2F.gvm%2Fgos%2Fgo1.17.7%2Fsrc%2Fruntime%2Fpanic.go%3A1038%0A++%2B0x215%5Cngithub.com%2Fnitrictech%2Fcli%2Fpkg%2Fcmd%2Fstack.glob..func4%280x4e2a760%2C+%7B0x4e77260%2C%0A++0x0%2C+0x0%7D%29%5Cn%5Ct%2Fhome%2Fangus%2Fcode%2Fgo%2Fsrc%2Fgithub.com%2Fnitrictech%2Fcli%2Fpkg%2Fcmd%2Fstack%2Froot.go%3A189%0A++%2B0x28%5Cngithub.com%2Fspf13%2Fcobra.%28%2ACommand%29.execute%280x4e2a760%2C+%7B0x4e77260%2C+0x0%2C+0x0%7D%29%5Cn%5Ct%2Fhome%2Fangus%2F.gvm%2Fpkgsets%2Fgo1.17.7%2Fglobal%2Fpkg%2Fmod%2Fgithub.com%2Fspf13%2Fcobra%40v1.3.0%2Fcommand.go%3A860%0A++%2B0x5f8%5Cngithub.com%2Fspf13%2Fcobra.%28%2ACommand%29.ExecuteC%280x4e2ac60%29%5Cn%5Ct%2Fhome%2Fangus%2F.gvm%2Fpkgsets%2Fgo1.17.7%2Fglobal%2Fpkg%2Fmod%2Fgithub.com%2Fspf13%2Fcobra%40v1.3.0%2Fcommand.go%3A974%0A++%2B0x3bc%5Cngithub.com%2Fspf13%2Fcobra.%28%2ACommand%29.Execute%28...%29%5Cn%5Ct%2Fhome%2Fangus%2F.gvm%2Fpkgsets%2Fgo1.17.7%2Fglobal%2Fpkg%2Fmod%2Fgithub.com%2Fspf13%2Fcobra%40v1.3.0%2Fcommand.go%3A902%5Cnmain.addAlias.func1%280x4e77260%2C%0A++%7B0x4e77260%2C+0x0%2C+0x4%7D%29%5Cn%5Ct%2Fhome%2Fangus%2Fcode%2Fgo%2Fsrc%2Fgithub.com%2Fnitrictech%2Fcli%2Fpkg%2Fcmd%2Froot.go%3A112%0A++%2B0x232%5Cngithub.com%2Fspf13%2Fcobra.%28%2ACommand%29.execute%280xc00012b900%2C+%7B0x4e77260%2C+0x0%2C%0A++0x0%7D%29%5Cn%5Ct%2Fhome%2Fangus%2F.gvm%2Fpkgsets%2Fgo1.17.7%2Fglobal%2Fpkg%2Fmod%2Fgithub.com%2Fspf13%2Fcobra%40v1.3.0%2Fcommand.go%3A860%0A++%2B0x5f8%5Cngithub.com%2Fspf13%2Fcobra.%28%2ACommand%29.ExecuteC%280x4e2ac60%29%5Cn%5Ct%2Fhome%2Fangus%2F.gvm%2Fpkgsets%2Fgo1.17.7%2Fglobal%2Fpkg%2Fmod%2Fgithub.com%2Fspf13%2Fcobra%40v1.3.0%2Fcommand.go%3A974%0A++%2B0x3bc%5Cngithub.com%2Fspf13%2Fcobra.%28%2ACommand%29.Execute%28...%29%5Cn%5Ct%2Fhome%2Fangus%2F.gvm%2Fpkgsets%2Fgo1.17.7%2Fglobal%2Fpkg%2Fmod%2Fgithub.com%2Fspf13%2Fcobra%40v1.3.0%2Fcommand.go%3A902%5Cnmain.Execute%28%29%5Cn%5Ct%2Fhome%2Fangus%2Fcode%2Fgo%2Fsrc%2Fgithub.com%2Fnitrictech%2Fcli%2Fpkg%2Fcmd%2Froot.go%3A76%0A++%2B0x45%5Cnmain.main%28%29%5Cn%5Ct%2Fhome%2Fangus%2Fcode%2Fgo%2Fsrc%2Fgithub.com%2Fnitrictech%2Fcli%2Fpkg%2Fcmd%2Fmain.go%3A20%0A++%2B0x17%5Cn%22%0A&title=Command+%27nitric+stack+list%27+paniced%3A+runtime+error%3A+invalid+memory+address+or+nil+point

closes #146