### PR TITLE
Fix: docker build error "repository name must be lowercase "

### DIFF
--- a/mocks/mock_containerengine/mock_containerengine.go
+++ b/mocks/mock_containerengine/mock_containerengine.go
@@ -40,17 +40,17 @@ func (m *MockContainerEngine) EXPECT() *MockContainerEngineMockRecorder {
 }
 
 // Build mocks base method.
-func (m *MockContainerEngine) Build(arg0, arg1, arg2 string, arg3 map[string]string) error {
+func (m *MockContainerEngine) Build(arg0, arg1, arg2 string, arg3 map[string]string, arg4 []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Build", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Build", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Build indicates an expected call of Build.
-func (mr *MockContainerEngineMockRecorder) Build(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockContainerEngineMockRecorder) Build(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Build", reflect.TypeOf((*MockContainerEngine)(nil).Build), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Build", reflect.TypeOf((*MockContainerEngine)(nil).Build), arg0, arg1, arg2, arg3, arg4)
 }
 
 // ContainerCreate mocks base method.

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -56,7 +56,7 @@ func Create(s *project.Project, t *stack.Config) error {
 		fh.Close()
 
 		buildArgs := map[string]string{"PROVIDER": t.Provider}
-		err = cr.Build(filepath.Base(fh.Name()), s.Dir, f.ImageTagName(s, t.Provider), buildArgs)
+		err = cr.Build(filepath.Base(fh.Name()), s.Dir, f.ImageTagName(s, t.Provider), buildArgs, rt.BuildIgnore())
 		if err != nil {
 			return err
 		}
@@ -64,7 +64,7 @@ func Create(s *project.Project, t *stack.Config) error {
 
 	for _, c := range s.Containers {
 		buildArgs := map[string]string{"PROVIDER": t.Provider}
-		err := cr.Build(filepath.Join(s.Dir, c.Dockerfile), s.Dir, c.ImageTagName(s, t.Provider), buildArgs)
+		err := cr.Build(filepath.Join(s.Dir, c.Dockerfile), s.Dir, c.ImageTagName(s, t.Provider), buildArgs, []string{})
 		if err != nil {
 			return err
 		}
@@ -104,7 +104,7 @@ func CreateBaseDev(s *project.Project) error {
 			return err
 		}
 
-		if err := ce.Build(filepath.Base(f.Name()), s.Dir, rt.DevImageName(), map[string]string{}); err != nil {
+		if err := ce.Build(filepath.Base(f.Name()), s.Dir, rt.DevImageName(), map[string]string{}, rt.BuildIgnore()); err != nil {
 			return err
 		}
 		imagesToBuild[lang] = rt.DevImageName()

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -42,7 +42,7 @@ func TestCreateBaseDev(t *testing.T) {
 	s := project.New(&project.Config{Name: "", Dir: dir})
 	s.Functions = map[string]project.Function{"foo": {Handler: "functions/list.ts"}}
 
-	me.EXPECT().Build(gomock.Any(), dir, "nitric-ts-dev", map[string]string{})
+	me.EXPECT().Build(gomock.Any(), dir, "nitric-ts-dev", map[string]string{}, []string{"node_modules/", ".nitric/", ".git/", ".idea/"})
 
 	containerengine.DiscoveredEngine = me
 
@@ -54,8 +54,8 @@ func TestCreateBaseDev(t *testing.T) {
 func TestCreate(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	me := mock_containerengine.NewMockContainerEngine(ctrl)
-	me.EXPECT().Build(gomock.Any(), ".", "test-stack--aws", map[string]string{"PROVIDER": "aws"})
-	me.EXPECT().Build("Dockerfile.custom", ".", "test-stack--aws", map[string]string{"PROVIDER": "aws"})
+	me.EXPECT().Build(gomock.Any(), ".", "test-stack--aws", map[string]string{"PROVIDER": "aws"}, []string{"node_modules/", ".nitric/", ".git/", ".idea/"})
+	me.EXPECT().Build("Dockerfile.custom", ".", "test-stack--aws", map[string]string{"PROVIDER": "aws"}, []string{})
 
 	containerengine.DiscoveredEngine = me
 

--- a/pkg/containerengine/docker.go
+++ b/pkg/containerengine/docker.go
@@ -120,7 +120,7 @@ func imageNameFromBuildContext(dockerfile, srcPath, imageTag string) (string, er
 		imageName = strings.Split(imageTag, ":")[0]
 	}
 
-	return imageName + ":" + hex.EncodeToString(hash.Sum(nil)), nil
+	return strings.ToLower(imageName + ":" + hex.EncodeToString(hash.Sum(nil))), nil
 }
 
 func (d *docker) Build(dockerfile, srcPath, imageTag string, buildArgs map[string]string) error {
@@ -148,7 +148,7 @@ func (d *docker) Build(dockerfile, srcPath, imageTag string, buildArgs map[strin
 	opts := types.ImageBuildOptions{
 		SuppressOutput: false,
 		Dockerfile:     dockerfile,
-		Tags:           []string{imageTag, imageTagWithHash},
+		Tags:           []string{strings.ToLower(imageTag), imageTagWithHash},
 		Remove:         true,
 		ForceRemove:    true,
 		PullParent:     true,

--- a/pkg/containerengine/podman.go
+++ b/pkg/containerengine/podman.go
@@ -81,8 +81,8 @@ func (p *podman) Type() string {
 	return "podman"
 }
 
-func (p *podman) Build(dockerfile, path, imageTag string, buildArgs map[string]string) error {
-	return p.docker.Build(dockerfile, path, imageTag, buildArgs)
+func (p *podman) Build(dockerfile, path, imageTag string, buildArgs map[string]string, excludes []string) error {
+	return p.docker.Build(dockerfile, path, imageTag, buildArgs, excludes)
 }
 
 func (p *podman) ListImages(stackName, containerName string) ([]Image, error) {

--- a/pkg/containerengine/types.go
+++ b/pkg/containerengine/types.go
@@ -44,7 +44,7 @@ type ContainerLogger interface {
 
 type ContainerEngine interface {
 	Type() string
-	Build(dockerfile, path, imageTag string, buildArgs map[string]string) error
+	Build(dockerfile, path, imageTag string, buildArgs map[string]string, excludes []string) error
 	ListImages(stackName, containerName string) ([]Image, error)
 	ImagePull(rawImage string) error
 	NetworkCreate(name string) error

--- a/pkg/runtime/generate_test.go
+++ b/pkg/runtime/generate_test.go
@@ -37,8 +37,7 @@ func TestGenerate(t *testing.T) {
 			version:  "latest",
 			provider: "azure",
 			wantFwriter: `FROM node:alpine
-RUN yarn global add typescript
-RUN yarn global add ts-node
+RUN yarn global add typescript ts-node
 COPY package.json *.lock *-lock.json /
 RUN yarn import || echo Lockfile already exists
 RUN set -ex; yarn install --production --frozen-lockfile --cache-folder /tmp/.cache; rm -rf /tmp/.cache;

--- a/pkg/runtime/golang.go
+++ b/pkg/runtime/golang.go
@@ -41,6 +41,10 @@ func (t *golang) DevImageName() string {
 	return fmt.Sprintf("nitric-%s-dev", t.rte)
 }
 
+func (t *golang) BuildIgnore() []string {
+	return []string{}
+}
+
 func (t *golang) ContainerName() string {
 	// get the abs dir in case user provides "."
 	absH, err := filepath.Abs(t.handler)

--- a/pkg/runtime/java.go
+++ b/pkg/runtime/java.go
@@ -59,6 +59,10 @@ func (t *java) LaunchOptsForFunction(runCtx string) (LaunchOpts, error) {
 	return LaunchOpts{}, utils.NewNotSupportedErr("code-as-config not supported on " + string(t.rte))
 }
 
+func (t *java) BuildIgnore() []string {
+	return []string{}
+}
+
 func (t *java) FunctionDockerfile(funcCtxDir, version, provider string, w io.Writer) error {
 	buildCon, err := dockerfile.NewContainer(dockerfile.NewContainerOpts{
 		From:   mavenOpenJDKImage,

--- a/pkg/runtime/javascript.go
+++ b/pkg/runtime/javascript.go
@@ -47,6 +47,10 @@ func (t *javascript) ContainerName() string {
 	return strings.Replace(filepath.Base(t.handler), filepath.Ext(t.handler), "", 1)
 }
 
+func (t *javascript) BuildIgnore() []string {
+	return javascriptIgnoreList
+}
+
 func (t *javascript) FunctionDockerfile(funcCtxDir, version, provider string, w io.Writer) error {
 	con, err := dockerfile.NewContainer(dockerfile.NewContainerOpts{
 		From:   "node:alpine",

--- a/pkg/runtime/python.go
+++ b/pkg/runtime/python.go
@@ -41,6 +41,10 @@ func (t *python) ContainerName() string {
 	return strings.Replace(filepath.Base(t.handler), filepath.Ext(t.handler), "", 1)
 }
 
+func (t *python) BuildIgnore() []string {
+	return []string{"__pycache__/", "*.py[cod]", "*$py.class"}
+}
+
 func (t *python) FunctionDockerfileForCodeAsConfig(w io.Writer) error {
 	return utils.NewNotSupportedErr("code-as-config not supported on " + string(t.rte))
 }
@@ -56,7 +60,7 @@ func (t *python) LaunchOptsForFunction(runCtx string) (LaunchOpts, error) {
 func (t *python) FunctionDockerfile(funcCtxDir, version, provider string, w io.Writer) error {
 	con, err := dockerfile.NewContainer(dockerfile.NewContainerOpts{
 		From:   "python:3.7-slim",
-		Ignore: []string{"__pycache__/", "*.py[cod]", "*$py.class"},
+		Ignore: t.BuildIgnore(),
 	})
 	if err != nil {
 		return err

--- a/pkg/runtime/types.go
+++ b/pkg/runtime/types.go
@@ -31,6 +31,7 @@ import (
 type Runtime interface {
 	DevImageName() string
 	ContainerName() string
+	BuildIgnore() []string
 	FunctionDockerfile(funcCtxDir, version, provider string, w io.Writer) error
 	FunctionDockerfileForCodeAsConfig(w io.Writer) error // FunctionDockerfileForCodeAsConfig generates a base image for code-as-config
 	LaunchOptsForFunction(stackDir string) (LaunchOpts, error)

--- a/pkg/runtime/typescript.go
+++ b/pkg/runtime/typescript.go
@@ -47,14 +47,14 @@ func (t *typescript) ContainerName() string {
 func (t *typescript) FunctionDockerfile(funcCtxDir, version, provider string, w io.Writer) error {
 	con, err := dockerfile.NewContainer(dockerfile.NewContainerOpts{
 		From:   "node:alpine",
-		Ignore: []string{"node_modules/", ".nitric/", ".git/", ".idea/"},
+		Ignore: javascriptIgnoreList,
 	})
 	if err != nil {
 		return err
 	}
 
-	con.Run(dockerfile.RunOptions{Command: []string{"yarn", "global", "add", "typescript"}})
-	con.Run(dockerfile.RunOptions{Command: []string{"yarn", "global", "add", "ts-node"}})
+	con.Run(dockerfile.RunOptions{Command: []string{"yarn", "global", "add", "typescript", "ts-node"}})
+
 	err = con.Copy(dockerfile.CopyOptions{Src: "package.json *.lock *-lock.json", Dest: "/"})
 	if err != nil {
 		return err
@@ -74,6 +74,7 @@ func (t *typescript) FunctionDockerfile(funcCtxDir, version, provider string, w 
 	con.Config(dockerfile.ConfigOptions{
 		Cmd: []string{"ts-node", "-T", filepath.ToSlash(t.handler)},
 	})
+
 	_, err = w.Write([]byte(strings.Join(con.Lines(), "\n")))
 	return err
 }
@@ -81,7 +82,7 @@ func (t *typescript) FunctionDockerfile(funcCtxDir, version, provider string, w 
 func (t *typescript) FunctionDockerfileForCodeAsConfig(w io.Writer) error {
 	con, err := dockerfile.NewContainer(dockerfile.NewContainerOpts{
 		From:   "node:alpine",
-		Ignore: []string{"node_modules/", ".nitric/", ".git/", ".idea/"},
+		Ignore: javascriptIgnoreList,
 	})
 	if err != nil {
 		return err

--- a/pkg/runtime/typescript.go
+++ b/pkg/runtime/typescript.go
@@ -44,6 +44,10 @@ func (t *typescript) ContainerName() string {
 	return strings.Replace(filepath.Base(t.handler), filepath.Ext(t.handler), "", 1)
 }
 
+func (t *typescript) BuildIgnore() []string {
+	return javascriptIgnoreList
+}
+
 func (t *typescript) FunctionDockerfile(funcCtxDir, version, provider string, w io.Writer) error {
 	con, err := dockerfile.NewContainer(dockerfile.NewContainerOpts{
 		From:   "node:alpine",


### PR DESCRIPTION
2 important fixes here:

commit cbf1d1a5d2dca51073bc3c00d4334a4e8f27608c

    fix: Make sure that Ignores make their way to docker build
    
    The problem is that boxygen Ignore has no effect. So publish
    a new function "BuildIgnore" on the runtime interface which
    is used by the build to pass to the docker excludes.

commit fe0bbab29c0e7ecb16d6c93189a0d21f3c3f578d

    fix: Make sure docker image names are lowercase
    
    closes #172
