### PR TITLE
Set MIN_WORKERS, based on registered function workers.

### DIFF
--- a/pkg/codeconfig/codeconfig.go
+++ b/pkg/codeconfig/codeconfig.go
@@ -476,6 +476,8 @@ func (c *codeConfig) ToProject() (*project.Project, error) {
 		fun.ComputeUnit.Triggers = project.Triggers{
 			Topics: topicTriggers,
 		}
+		// set the functions worker count
+		fun.WorkerCount = f.WorkerCount()
 		s.Functions[f.name] = fun
 	}
 

--- a/pkg/codeconfig/function.go
+++ b/pkg/codeconfig/function.go
@@ -134,6 +134,18 @@ func (a *FunctionDependencies) AddSubscriptionHandler(sw *pb.SubscriptionWorker)
 	return nil
 }
 
+func (a *FunctionDependencies) WorkerCount() int {
+	workerCount := 0
+
+	for _, v := range a.apis {
+		workerCount = workerCount + len(v.workers)
+	}
+
+	workerCount = workerCount + len(a.subscriptions) + len(a.schedules)
+
+	return workerCount
+}
+
 // AddScheduleHandler - registers a handler in the function that runs on a schedule
 func (a *FunctionDependencies) AddScheduleHandler(sw *pb.ScheduleWorker) error {
 	a.lock.Lock()

--- a/pkg/project/container_helper.go
+++ b/pkg/project/container_helper.go
@@ -35,3 +35,8 @@ func (c *Container) ImageTagName(s *Project, provider string) string {
 	}
 	return fmt.Sprintf("%s-%s%s", s.Name, c.Name, providerString)
 }
+
+func (c *Container) Workers() int {
+	// Default to expecting a minimum of 1 worker for containers
+	return 1
+}

--- a/pkg/project/function_helpers.go
+++ b/pkg/project/function_helpers.go
@@ -56,3 +56,7 @@ func (f *Function) ImageTagName(s *Project, provider string) string {
 	}
 	return fmt.Sprintf("%s-%s%s", s.Name, f.Name, providerString)
 }
+
+func (c *Function) Workers() int {
+	return c.WorkerCount
+}

--- a/pkg/project/types.go
+++ b/pkg/project/types.go
@@ -54,6 +54,9 @@ type Function struct {
 	Handler string `yaml:"handler"`
 
 	ComputeUnit `yaml:",inline"`
+
+	// The number of workers this function contains
+	WorkerCount int
 }
 
 type Container struct {
@@ -66,6 +69,7 @@ type Container struct {
 type Compute interface {
 	ImageTagName(s *Project, provider string) string
 	Unit() *ComputeUnit
+	Workers() int
 }
 
 // A subset of a NitricEvent

--- a/pkg/provider/pulumi/aws/lambda.go
+++ b/pkg/provider/pulumi/aws/lambda.go
@@ -132,6 +132,7 @@ func newLambda(ctx *pulumi.Context, name string, args *LambdaArgs, opts ...pulum
 		Environment: awslambda.FunctionEnvironmentArgs{
 			Variables: pulumi.StringMap{
 				"NITRIC_STACK": pulumi.String(args.StackName),
+				"MIN_WORKERS":  pulumi.String(fmt.Sprint(args.Compute.Workers())),
 			},
 		},
 	}, opts...)

--- a/pkg/provider/pulumi/azure/containerapp.go
+++ b/pkg/provider/pulumi/azure/containerapp.go
@@ -17,6 +17,8 @@
 package azure
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	web "github.com/pulumi/pulumi-azure-native/sdk/go/azure/web/v20210301"
 	"github.com/pulumi/pulumi-azure/sdk/v4/go/azure/authorization"
@@ -235,6 +237,10 @@ func (a *azureProvider) newContainerApp(ctx *pulumi.Context, name string, args *
 	}
 
 	env := web.EnvironmentVarArray{
+		web.EnvironmentVarArgs{
+			Name:  pulumi.String("MIN_WORKERS"),
+			Value: pulumi.String(fmt.Sprint(args.Compute.Workers())),
+		},
 		web.EnvironmentVarArgs{
 			Name:  pulumi.String("AZURE_SUBSCRIPTION_ID"),
 			Value: args.SubscriptionID,

--- a/pkg/provider/pulumi/gcp/cloudrunner.go
+++ b/pkg/provider/pulumi/gcp/cloudrunner.go
@@ -17,6 +17,8 @@
 package gcp
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/cloudrun"
 	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/projects"
@@ -104,6 +106,12 @@ func (g *gcpProvider) newCloudRunner(ctx *pulumi.Context, name string, args *Clo
 				ServiceAccountName: sa.Email,
 				Containers: cloudrun.ServiceTemplateSpecContainerArray{
 					cloudrun.ServiceTemplateSpecContainerArgs{
+						Envs: cloudrun.ServiceTemplateSpecContainerEnvArray{
+							cloudrun.ServiceTemplateSpecContainerEnvArgs{
+								Name:  pulumi.String("MIN_WORKERS"),
+								Value: pulumi.String(fmt.Sprint(args.Compute.Workers())),
+							},
+						},
 						Image: args.Image.DockerImage.ImageName, // TODO check
 						Ports: cloudrun.ServiceTemplateSpecContainerPortArray{
 							cloudrun.ServiceTemplateSpecContainerPortArgs{


### PR DESCRIPTION
This fix will ensure the gateway will block, until all available workers have successfully registered.

Currently there is a race condition in azure container apps that allows the application to response before all workers are ready, causing erroneous errors.