### PR TITLE
fix: go install of CompileDaemon

### DIFF
--- a/pkg/runtime/generate_test.go
+++ b/pkg/runtime/generate_test.go
@@ -221,7 +221,7 @@ ENTRYPOINT ["node"]`,
 		{
 			handler: "pkg/list/main.go",
 			wantFwriter: `FROM golang:alpine
-RUN go get github.com/asalkeld/CompileDaemon@d4b10de`,
+RUN go install github.com/asalkeld/CompileDaemon@d4b10de`,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/runtime/golang.go
+++ b/pkg/runtime/golang.go
@@ -117,7 +117,7 @@ func (t *golang) FunctionDockerfileForCodeAsConfig(w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	con.Run(dockerfile.RunOptions{Command: []string{"go", "get", "github.com/asalkeld/CompileDaemon@d4b10de"}})
+	con.Run(dockerfile.RunOptions{Command: []string{"go", "install", "github.com/asalkeld/CompileDaemon@d4b10de"}})
 
 	_, err = w.Write([]byte(strings.Join(con.Lines(), "\n")))
 	return err


### PR DESCRIPTION
New versions of golang don't like "go get" to install