### PR TITLE
chore: fix go releaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,7 +12,6 @@ builds:
       - CGO_ENABLED=0
     id: nitric
     binary: nitric
-    main: ./pkg/cmd/
     goos:
       - linux
       - windows


### PR DESCRIPTION
main moved to root, so this config isn't required anymore