### PR TITLE
feat: add support for .env files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/hashicorp/go-getter v1.5.11
 	github.com/imdario/mergo v0.3.12
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
+	github.com/joho/godotenv v1.3.0
 	github.com/klauspost/compress v1.15.1 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect

--- a/go.sum
+++ b/go.sum
@@ -1114,6 +1114,7 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/jmoiron/sqlx v1.2.1-0.20190826204134-d7d95172beb5/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -155,7 +155,7 @@ func cmdUsage(prefix []string, c *cobra.Command, commonOnly bool) []string {
 	}
 
 	if add {
-		cmdH = append(cmdH, fmt.Sprintf("- %-22s : %s", use, c.Short))
+		cmdH = append(cmdH, fmt.Sprintf("- %s : %s", use, c.Short))
 		if _, ok := c.Annotations["alias:to"]; ok {
 			use = "nitric " + c.Annotations["alias:to"]
 			cmdH = append(cmdH, fmt.Sprintf("  (alias: %s)", use))

--- a/pkg/provider/generator.go
+++ b/pkg/provider/generator.go
@@ -26,10 +26,10 @@ import (
 	"github.com/nitrictech/cli/pkg/utils"
 )
 
-func NewProvider(p *project.Project, s *stack.Config) (types.Provider, error) {
+func NewProvider(p *project.Project, s *stack.Config, envMap map[string]string) (types.Provider, error) {
 	switch s.Provider {
 	case stack.Aws, stack.Azure, stack.Digitalocean, stack.Gcp:
-		return pulumi.New(p, s)
+		return pulumi.New(p, s, envMap)
 	default:
 		return nil, utils.NewNotSupportedErr(fmt.Sprintf("provider %s is not supported", s.Provider))
 	}

--- a/pkg/provider/pulumi/aws/aws.go
+++ b/pkg/provider/pulumi/aws/aws.go
@@ -50,6 +50,7 @@ import (
 type awsProvider struct {
 	proj   *project.Project
 	sc     *stack.Config
+	envMap map[string]string
 	tmpDir string
 
 	// created resources (mostly here for testing)
@@ -67,10 +68,11 @@ type awsProvider struct {
 //go:embed pulumi-aws-version.txt
 var awsPluginVersion string
 
-func New(s *project.Project, t *stack.Config) common.PulumiProvider {
+func New(s *project.Project, t *stack.Config, envMap map[string]string) common.PulumiProvider {
 	return &awsProvider{
 		proj:        s,
 		sc:          t,
+		envMap:      envMap,
 		topics:      map[string]*sns.Topic{},
 		buckets:     map[string]*s3.Bucket{},
 		queues:      map[string]*sqs.Queue{},
@@ -303,6 +305,7 @@ func (a *awsProvider) Deploy(ctx *pulumi.Context) error {
 			DockerImage: image.DockerImage,
 			Compute:     c,
 			StackName:   ctx.Stack(),
+			EnvMap:      a.envMap,
 		})
 		if err != nil {
 			return errors.WithMessage(err, "lambda container "+c.Unit().Name)

--- a/pkg/provider/pulumi/aws/aws_test.go
+++ b/pkg/provider/pulumi/aws/aws_test.go
@@ -264,7 +264,7 @@ func TestValidate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			a := New(nil, tt.t)
+			a := New(nil, tt.t, map[string]string{})
 			if err := a.Validate(); (err != nil) != tt.wantErr {
 				t.Errorf("awsProvider.Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/provider/pulumi/azure/azure.go
+++ b/pkg/provider/pulumi/azure/azure.go
@@ -43,6 +43,7 @@ import (
 type azureProvider struct {
 	proj       *project.Project
 	sc         *stack.Config
+	envMap     map[string]string
 	tmpDir     string
 	org        string
 	adminEmail string
@@ -57,8 +58,12 @@ var (
 	azureNativePluginVersion string
 )
 
-func New(s *project.Project, t *stack.Config) common.PulumiProvider {
-	return &azureProvider{proj: s, sc: t}
+func New(s *project.Project, t *stack.Config, envMap map[string]string) common.PulumiProvider {
+	return &azureProvider{
+		proj:   s,
+		sc:     t,
+		envMap: envMap,
+	}
 }
 
 func (a *azureProvider) Plugins() []common.Plugin {
@@ -199,6 +204,7 @@ func (a *azureProvider) Deploy(ctx *pulumi.Context) error {
 		Location:          rg.Location,
 		SubscriptionID:    pulumi.String(clientConfig.SubscriptionId),
 		Topics:            map[string]*eventgrid.Topic{},
+		EnvMap:            a.envMap,
 	}
 
 	// Create a stack level keyvault if secrets are enabled

--- a/pkg/provider/pulumi/azure/containerapp.go
+++ b/pkg/provider/pulumi/azure/containerapp.go
@@ -35,6 +35,7 @@ type ContainerAppsArgs struct {
 	ResourceGroupName pulumi.StringInput
 	Location          pulumi.StringInput
 	SubscriptionID    pulumi.StringInput
+	EnvMap            map[string]string
 
 	Topics map[string]*eventgrid.Topic
 
@@ -97,6 +98,13 @@ func (a *azureProvider) newContainerApps(ctx *pulumi.Context, name string, args 
 		env = append(env, web.EnvironmentVarArgs{
 			Name:  pulumi.String("KVAULT_NAME"),
 			Value: args.KVaultName,
+		})
+	}
+
+	for k, v := range args.EnvMap {
+		env = append(env, web.EnvironmentVarArgs{
+			Name:  pulumi.String(k),
+			Value: pulumi.String(v),
 		})
 	}
 

--- a/pkg/provider/pulumi/gcp/gcp.go
+++ b/pkg/provider/pulumi/gcp/gcp.go
@@ -56,6 +56,7 @@ import (
 type gcpProvider struct {
 	sc         *stack.Config
 	proj       *project.Project
+	envMap     map[string]string
 	tmpDir     string
 	gcpProject string
 
@@ -75,10 +76,11 @@ type gcpProvider struct {
 //go:embed pulumi-gcp-version.txt
 var gcpPluginVersion string
 
-func New(s *project.Project, t *stack.Config) common.PulumiProvider {
+func New(s *project.Project, t *stack.Config, envMap map[string]string) common.PulumiProvider {
 	return &gcpProvider{
 		proj:               s,
 		sc:                 t,
+		envMap:             envMap,
 		buckets:            map[string]*storage.Bucket{},
 		topics:             map[string]*pubsub.Topic{},
 		queueTopics:        map[string]*pubsub.Topic{},
@@ -389,6 +391,7 @@ func (g *gcpProvider) Deploy(ctx *pulumi.Context) error {
 			Compute:        c,
 			Image:          g.images[c.Unit().Name],
 			ServiceAccount: sa,
+			EnvMap:         g.envMap,
 		}, defaultResourceOptions)
 		if err != nil {
 			return err

--- a/pkg/provider/pulumi/gcp/gcp_test.go
+++ b/pkg/provider/pulumi/gcp/gcp_test.go
@@ -214,7 +214,7 @@ func TestValidate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			a := New(nil, tt.t)
+			a := New(nil, tt.t, map[string]string{})
 			if err := a.Validate(); (err != nil) != tt.wantErr {
 				t.Errorf("gcpProvider.Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/provider/pulumi/generator.go
+++ b/pkg/provider/pulumi/generator.go
@@ -57,7 +57,7 @@ var (
 	_ types.Provider = &pulumiDeployment{}
 )
 
-func New(p *project.Project, sc *stack.Config) (types.Provider, error) {
+func New(p *project.Project, sc *stack.Config, envMap map[string]string) (types.Provider, error) {
 	pv := exec.Command("pulumi", "version")
 	err := pv.Run()
 	if err != nil {
@@ -70,11 +70,11 @@ func New(p *project.Project, sc *stack.Config) (types.Provider, error) {
 	var prov common.PulumiProvider
 	switch sc.Provider {
 	case stack.Aws:
-		prov = aws.New(p, sc)
+		prov = aws.New(p, sc, envMap)
 	case stack.Azure:
-		prov = azure.New(p, sc)
+		prov = azure.New(p, sc, envMap)
 	case stack.Gcp:
-		prov = gcp.New(p, sc)
+		prov = gcp.New(p, sc, envMap)
 	default:
 		return nil, utils.NewNotSupportedErr("pulumi provider " + sc.Provider + " not suppored")
 	}

--- a/pkg/utils/glob.go
+++ b/pkg/utils/glob.go
@@ -49,3 +49,21 @@ func GlobInDir(dir, pattern string) ([]string, error) {
 	}
 	return final, nil
 }
+
+func FilesExisting(files ...string) []string {
+	existing := []string{}
+	for _, f := range files {
+		if f == "" {
+			continue
+		}
+		info, err := os.Stat(f)
+		if err != nil {
+			continue
+		}
+		if info.IsDir() {
+			continue
+		}
+		existing = append(existing, f)
+	}
+	return existing
+}


### PR DESCRIPTION
How this works:

- for "nitric run", look for files in this order --env-file, .local, .env and set this in the running container
- for "nitric up", look for files in this order --env-file, .production, .env  and insert into the functions

(still needs some testing)

implements #187