### PR TITLE
fix: use polling for hot reloading go sdk on windows

### DIFF
--- a/pkg/runtime/generate_test.go
+++ b/pkg/runtime/generate_test.go
@@ -280,7 +280,7 @@ func TestLaunchOptsForFunction(t *testing.T) {
 					"-verbose",
 					"-exclude-dir=.git",
 					"-exclude-dir=.nitric",
-					"-directory=.", "-build=go build -o runtime ././...", "-command=./runtime"},
+					"-directory=.", "-polling=false", "-build=go build -o runtime ././...", "-command=./runtime"},
 				Mounts: []mount.Mount{
 					{
 						Type: "bind", Source: filepath.Join(os.Getenv("GOPATH"), "pkg"), Target: "/go/pkg",

--- a/pkg/runtime/golang.go
+++ b/pkg/runtime/golang.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	osruntime "runtime"
 	"strings"
 
 	"github.com/docker/docker/api/types/mount"
@@ -177,6 +178,7 @@ func (t *golang) LaunchOptsForFunction(runCtx string) (LaunchOpts, error) {
 			"-exclude-dir=.git",
 			"-exclude-dir=.nitric",
 			"-directory=.",
+			fmt.Sprintf("-polling=%t", osruntime.GOOS == "windows"),
 			fmt.Sprintf("-build=go build -o %s ./%s/...", t.ContainerName(), filepath.ToSlash(filepath.Dir(relHandler))),
 			"-command=./" + t.ContainerName(),
 		},


### PR DESCRIPTION
Fixes #215 