### PR TITLE
fix: make the -s stack flag required

### DIFF
--- a/pkg/stack/options.go
+++ b/pkg/stack/options.go
@@ -67,6 +67,11 @@ func AddOptions(cmd *cobra.Command, providerOnly bool) error {
 	}
 
 	cmd.Flags().VarP(pflagext.NewStringEnumVar(&stack, stacks, ""), "stack", "s", "use this to refer to a stack configuration nitric-<stackname>.yaml")
+
+	if err = cobra.MarkFlagRequired(cmd.Flags(), "stack"); err != nil {
+		return err
+	}
+
 	return cmd.RegisterFlagCompletionFunc("stack", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return stacks, cobra.ShellCompDirectiveDefault
 	})


### PR DESCRIPTION
This does the following:

```
$ nitric up
Error: required flag(s) "stack" not set
Usage:
  nitric stack update [-s stack] [flags]

```

closes #220