### PR TITLE
feat: use default go path if env var isn't set

### DIFF
--- a/pkg/runtime/generate_test.go
+++ b/pkg/runtime/generate_test.go
@@ -18,12 +18,12 @@ package runtime
 
 import (
 	"bytes"
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/docker/docker/api/types/mount"
 	"github.com/google/go-cmp/cmp"
+	"github.com/nitrictech/cli/pkg/utils"
 )
 
 func TestGenerate(t *testing.T) {
@@ -245,6 +245,11 @@ RUN go install github.com/asalkeld/CompileDaemon@d4b10de`,
 }
 
 func TestLaunchOptsForFunction(t *testing.T) {
+	goPath, err := utils.GoPath()
+	if err != nil {
+		panic(err)
+	}
+
 	tests := []struct {
 		handler string
 		runCtx  string
@@ -283,7 +288,7 @@ func TestLaunchOptsForFunction(t *testing.T) {
 					"-directory=.", "-polling=false", "-build=go build -o runtime ././...", "-command=./runtime"},
 				Mounts: []mount.Mount{
 					{
-						Type: "bind", Source: filepath.Join(os.Getenv("GOPATH"), "pkg"), Target: "/go/pkg",
+						Type: "bind", Source: filepath.Join(goPath, "pkg"), Target: "/go/pkg",
 					},
 					{
 						Type: "bind", Source: "../../", Target: "/go/src/github.com/nitrictech/cli",
@@ -311,6 +316,11 @@ func TestLaunchOptsForFunction(t *testing.T) {
 }
 
 func TestLaunchOptsForFunctionCollect(t *testing.T) {
+	goPath, err := utils.GoPath()
+	if err != nil {
+		panic(err)
+	}
+
 	tests := []struct {
 		handler string
 		runCtx  string
@@ -348,7 +358,7 @@ func TestLaunchOptsForFunctionCollect(t *testing.T) {
 					"go", "run", "././..."},
 				Mounts: []mount.Mount{
 					{
-						Type: "bind", Source: filepath.Join(os.Getenv("GOPATH"), "pkg"), Target: "/go/pkg",
+						Type: "bind", Source: filepath.Join(goPath, "pkg"), Target: "/go/pkg",
 					},
 					{
 						Type: "bind", Source: "../../", Target: "/go/src/github.com/nitrictech/cli",

--- a/pkg/runtime/generate_test.go
+++ b/pkg/runtime/generate_test.go
@@ -248,7 +248,7 @@ RUN go install github.com/asalkeld/CompileDaemon@d4b10de`,
 func TestLaunchOptsForFunction(t *testing.T) {
 	goPath, err := utils.GoPath()
 	if err != nil {
-		panic(err)
+		t.Error(err)
 	}
 
 	tests := []struct {
@@ -319,7 +319,7 @@ func TestLaunchOptsForFunction(t *testing.T) {
 func TestLaunchOptsForFunctionCollect(t *testing.T) {
 	goPath, err := utils.GoPath()
 	if err != nil {
-		panic(err)
+		t.Error(err)
 	}
 
 	tests := []struct {

--- a/pkg/runtime/generate_test.go
+++ b/pkg/runtime/generate_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/docker/docker/api/types/mount"
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/nitrictech/cli/pkg/utils"
 )
 

--- a/pkg/runtime/golang.go
+++ b/pkg/runtime/golang.go
@@ -19,7 +19,6 @@ package runtime
 import (
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	osruntime "runtime"
 	"strings"
@@ -137,6 +136,11 @@ func (t *golang) LaunchOptsForFunctionCollect(runCtx string) (LaunchOpts, error)
 		return LaunchOpts{}, err
 	}
 
+	goPath, err := utils.GoPath()
+	if err != nil {
+		return LaunchOpts{}, err
+	}
+
 	return LaunchOpts{
 		Image:    t.DevImageName(),
 		TargetWD: filepath.ToSlash(filepath.Join("/go/src", module)),
@@ -144,7 +148,7 @@ func (t *golang) LaunchOptsForFunctionCollect(runCtx string) (LaunchOpts, error)
 		Mounts: []mount.Mount{
 			{
 				Type:   "bind",
-				Source: filepath.Join(os.Getenv("GOPATH"), "pkg"),
+				Source: filepath.Join(goPath, "pkg"),
 				Target: "/go/pkg",
 			},
 			{
@@ -170,6 +174,11 @@ func (t *golang) LaunchOptsForFunction(runCtx string) (LaunchOpts, error) {
 		}
 	}
 
+	goPath, err := utils.GoPath()
+	if err != nil {
+		return LaunchOpts{}, err
+	}
+
 	opts := LaunchOpts{
 		TargetWD: containerRunCtx,
 		Cmd: strslice.StrSlice{
@@ -185,7 +194,7 @@ func (t *golang) LaunchOptsForFunction(runCtx string) (LaunchOpts, error) {
 		Mounts: []mount.Mount{
 			{
 				Type:   "bind",
-				Source: filepath.Join(os.Getenv("GOPATH"), "pkg"),
+				Source: filepath.Join(goPath, "pkg"),
 				Target: "/go/pkg",
 			},
 			{

--- a/pkg/utils/paths.go
+++ b/pkg/utils/paths.go
@@ -17,6 +17,7 @@
 package utils
 
 import (
+	"go/build"
 	"log"
 	"os"
 	"os/user"
@@ -116,13 +117,9 @@ func NewNitricLogFile(stackPath string) (string, error) {
 }
 
 func GoPath() (string, error) {
-	goPath := strings.TrimSpace(os.Getenv("GOPATH"))
+	goPath := os.Getenv("GOPATH")
 	if goPath == "" {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		goPath = filepath.Join(homeDir, "go")
+		goPath = build.Default.GOPATH
 	}
 	return goPath, nil
 }

--- a/pkg/utils/paths.go
+++ b/pkg/utils/paths.go
@@ -114,3 +114,15 @@ func NewNitricLogFile(stackPath string) (string, error) {
 	tf.Close()
 	return tf.Name(), nil
 }
+
+func GoPath() (string, error) {
+	goPath := strings.TrimSpace(os.Getenv("GOPATH"))
+	if goPath == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		goPath = filepath.Join(homeDir, "go")
+	}
+	return goPath, nil
+}


### PR DESCRIPTION
The default go path is ~/go which can be used if the GOPATH variable isn't set. If the home directory can't be determined, we error since the mount will fail anyway