### PR TITLE
feat: make SupportedRegions public on the provider

### DIFF
--- a/pkg/provider/pulumi/common/types.go
+++ b/pkg/provider/pulumi/common/types.go
@@ -42,6 +42,7 @@ type PulumiProvider interface {
 	CleanUp()
 	Ask() (*stack.Config, error)
 	TryPullImages() error
+	SupportedRegions() []string
 }
 
 func Tags(ctx *pulumi.Context, name string) pulumi.StringMap {

--- a/pkg/provider/pulumi/generator.go
+++ b/pkg/provider/pulumi/generator.go
@@ -94,6 +94,10 @@ func (p *pulumiDeployment) TryPullImages() error {
 	return p.prov.TryPullImages()
 }
 
+func (p *pulumiDeployment) SupportedRegions() []string {
+	return p.prov.SupportedRegions()
+}
+
 func (p *pulumiDeployment) load(log output.Progress) (*auto.Stack, error) {
 	if err := p.prov.Validate(); err != nil {
 		return nil, err

--- a/pkg/provider/types/interface.go
+++ b/pkg/provider/types/interface.go
@@ -31,5 +31,6 @@ type Provider interface {
 	List() (interface{}, error)
 	Ask() (*stack.Config, error)
 	TryPullImages() error
+	SupportedRegions() []string
 	//Status()
 }


### PR DESCRIPTION
This is so we can use this outside of the cli and not have to copy the supported regions.