### PR TITLE
fix(gcp): remove the ApiConfigId property so it can be auto assigned

### DIFF
--- a/pkg/provider/pulumi/gcp/gateway.go
+++ b/pkg/provider/pulumi/gcp/gateway.go
@@ -161,7 +161,6 @@ func newApiGateway(ctx *pulumi.Context, name string, args *ApiGatewayArgs, opts 
 		Project:     args.ProjectId,
 		Api:         res.Api.ApiId,
 		DisplayName: pulumi.String(name + "-config"),
-		ApiConfigId: pulumi.String(name + "-config"),
 		OpenapiDocuments: apigateway.ApiConfigOpenapiDocumentArray{
 			apigateway.ApiConfigOpenapiDocumentArgs{
 				Document: apigateway.ApiConfigOpenapiDocumentDocumentArgs{


### PR DESCRIPTION
Otherwise when it replaces the resource the id will clash.


Tested, and works!