### PR TITLE
feat: support templates with nitric.yaml files

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Documentation for all available commands:
 
 - nitric feedback : Provide feedback on your experience with nitric
 - nitric info : Gather information about Nitric and the environment
-- nitric new [projectName] [templateName] [handlerGlob] : Create a new project
+- nitric new [projectName] [templateName] : Create a new project
 - nitric run : Run your project locally for development and testing
 - nitric stack : Manage stacks (the deployed app containing multiple resources e.g. collection, bucket, topic)
 - nitric stack down [-s stack] : Undeploy a previously deployed stack, deleting resources
@@ -69,3 +69,4 @@ Documentation for all available commands:
 
 Check out the [Nitric docs](https://nitric.io/docs) to see how to get started using Nitric.
 cs](https://nitric.io/docs) to see how to get started using Nitric.
+using Nitric.

--- a/pkg/cmd/run/root.go
+++ b/pkg/cmd/run/root.go
@@ -57,7 +57,7 @@ var runCmd = &cobra.Command{
 		// Divert default log output to pterm debug
 		log.SetOutput(output.NewPtermWriter(pterm.Debug))
 
-		config, err := project.ConfigFromFile()
+		config, err := project.ConfigFromProjectPath("")
 		cobra.CheckErr(err)
 
 		proj, err := project.FromConfig(config)

--- a/pkg/cmd/stack/root.go
+++ b/pkg/cmd/stack/root.go
@@ -75,7 +75,7 @@ var newStackCmd = &cobra.Command{
 		}, &pName)
 		cobra.CheckErr(err)
 
-		pc, err := project.ConfigFromFile()
+		pc, err := project.ConfigFromProjectPath("")
 		cobra.CheckErr(err)
 
 		prov, err := provider.NewProvider(project.New(pc), &stack.Config{Name: name, Provider: pName}, map[string]string{})
@@ -106,7 +106,7 @@ var stackUpdateCmd = &cobra.Command{
 		s, err := stack.ConfigFromOptions()
 		cobra.CheckErr(err)
 
-		config, err := project.ConfigFromFile()
+		config, err := project.ConfigFromProjectPath("")
 		cobra.CheckErr(err)
 
 		proj, err := project.FromConfig(config)
@@ -194,7 +194,7 @@ nitric stack down -e aws -y`,
 		s, err := stack.ConfigFromOptions()
 		cobra.CheckErr(err)
 
-		config, err := project.ConfigFromFile()
+		config, err := project.ConfigFromProjectPath("")
 		cobra.CheckErr(err)
 
 		proj, err := project.FromConfig(config)
@@ -229,7 +229,7 @@ nitric stack list -s aws
 		s, err := stack.ConfigFromOptions()
 		cobra.CheckErr(err)
 
-		config, err := project.ConfigFromFile()
+		config, err := project.ConfigFromProjectPath("")
 		cobra.CheckErr(err)
 
 		proj, err := project.FromConfig(config)

--- a/pkg/project/config.go
+++ b/pkg/project/config.go
@@ -44,14 +44,17 @@ func (p *Config) ToFile() error {
 	return ioutil.WriteFile(filepath.Join(p.Dir, "nitric.yaml"), b, 0644)
 }
 
-// Assume the project is in the currentDirectory
-func ConfigFromFile() (*Config, error) {
-	wd, err := os.Getwd()
-	if err != nil {
-		return nil, err
+// ConfigFromProjectPath - loads the config nitric.yaml file from the project path, defaults to the current working directory
+func ConfigFromProjectPath(projPath string) (*Config, error) {
+	if projPath == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+		projPath = wd
 	}
 
-	absDir, err := filepath.Abs(wd)
+	absDir, err := filepath.Abs(projPath)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +62,7 @@ func ConfigFromFile() (*Config, error) {
 	p := &Config{
 		Dir: absDir,
 	}
-	yamlFile, err := ioutil.ReadFile(filepath.Join(wd, "nitric.yaml"))
+	yamlFile, err := ioutil.ReadFile(filepath.Join(projPath, "nitric.yaml"))
 	if err != nil {
 		return nil, errors.WithMessage(err, "No nitric project found (unable to find nitric.yaml). If you haven't created a project yet, run `nitric new` to get started")
 	}


### PR DESCRIPTION
fixes: https://github.com/nitrictech/cli/issues/197

Provides backwards compatibility with old templates by prompting for a handler glob if the nitric.yaml isn't found in the downloaded template