### PR TITLE
Feat/remaining lock file

### DIFF
--- a/pkg/provider/generator.go
+++ b/pkg/provider/generator.go
@@ -26,21 +26,10 @@ import (
 	"github.com/nitrictech/cli/pkg/utils"
 )
 
-func getProviderOpts[T interface{}](opts []interface{}) *T {
-	for _, o := range opts {
-		t, ok := o.(*T)
-		if ok {
-			return t
-		}
-	}
-	return nil
-}
-
-func NewProvider(p *project.Project, s *stack.Config, envMap map[string]string, opts ...interface{}) (types.Provider, error) {
+func NewProvider(p *project.Project, s *stack.Config, envMap map[string]string, opts *types.ProviderOpts) (types.Provider, error) {
 	switch s.Provider {
 	case stack.Aws, stack.Azure, stack.Digitalocean, stack.Gcp:
-		pulumiOpts := getProviderOpts[pulumi.PulumiOpts](opts)
-		return pulumi.New(p, s, envMap, pulumiOpts)
+		return pulumi.New(p, s, envMap, opts)
 	default:
 		return nil, utils.NewNotSupportedErr(fmt.Sprintf("provider %s is not supported", s.Provider))
 	}

--- a/pkg/provider/generator.go
+++ b/pkg/provider/generator.go
@@ -26,10 +26,21 @@ import (
 	"github.com/nitrictech/cli/pkg/utils"
 )
 
-func NewProvider(p *project.Project, s *stack.Config, envMap map[string]string) (types.Provider, error) {
+func getProviderOpts[T interface{}](opts []interface{}) *T {
+	for _, o := range opts {
+		t, ok := o.(*T)
+		if ok {
+			return t
+		}
+	}
+	return nil
+}
+
+func NewProvider(p *project.Project, s *stack.Config, envMap map[string]string, opts ...interface{}) (types.Provider, error) {
 	switch s.Provider {
 	case stack.Aws, stack.Azure, stack.Digitalocean, stack.Gcp:
-		return pulumi.New(p, s, envMap)
+		pulumiOpts := getProviderOpts[pulumi.PulumiOpts](opts)
+		return pulumi.New(p, s, envMap, pulumiOpts)
 	default:
 		return nil, utils.NewNotSupportedErr(fmt.Sprintf("provider %s is not supported", s.Provider))
 	}

--- a/pkg/provider/pulumi/generator.go
+++ b/pkg/provider/pulumi/generator.go
@@ -141,7 +141,7 @@ func (p *pulumiDeployment) load(log output.Progress) (*auto.Stack, error) {
 	log.Busyf("Refreshing the Pulumi stack")
 	_, err = s.Refresh(ctx)
 	if err != nil && strings.Contains(err.Error(), "[409] Conflict") {
-		return &s, errors.WithMessage(fmt.Errorf("Stack conflict occured. If you are sure an update is not in progress, use --force to override the stack state."), "Refresh")
+		return &s, errors.WithMessage(fmt.Errorf("Stack conflict occurred. If you are sure an update is not in progress, use --force to override the stack state."), "Refresh")
 	}
 	return &s, errors.WithMessage(err, "Refresh")
 }

--- a/pkg/provider/pulumi/generator.go
+++ b/pkg/provider/pulumi/generator.go
@@ -113,9 +113,14 @@ func (p *pulumiDeployment) load(log output.Progress) (*auto.Stack, error) {
 			Runtime: workspace.NewProjectRuntimeInfo("go", nil),
 			Main:    p.proj.Dir,
 		}))
+
 	if err != nil {
 		return nil, errors.WithMessage(err, "UpsertStackInlineSource")
 	}
+
+	// Cancel all previously running stacks
+	// It will only return an error if the stack isn't in an updating state, so we can just ignore it
+	_ = s.Cancel(ctx)
 
 	for _, plug := range p.prov.Plugins() {
 		log.Busyf("Installing Pulumi plugin %s:%s", plug.Name, plug.Version)

--- a/pkg/provider/types/interface.go
+++ b/pkg/provider/types/interface.go
@@ -25,6 +25,10 @@ type Deployment struct {
 	ApiEndpoints map[string]string `json:"apiEndpoints,omitempty"`
 }
 
+type ProviderOpts struct {
+	Force bool
+}
+
 type Provider interface {
 	Up(log output.Progress) (*Deployment, error)
 	Down(log output.Progress) error


### PR DESCRIPTION
Fixes #104

Has to be configurable via an override flag on the `nitric up` command as a conflict is a valid reason to fail if there is more than 1 person working on a stack concurrently. If we make it the default to cancel the updating stack, the other person will lose their update progress. Thus, I've added a flag `-c` or `--cancel`, to cancel the current update in progress. 