### PR TITLE
fix: improve output when publishing to local topics

### DIFF
--- a/pkg/run/events.go
+++ b/pkg/run/events.go
@@ -65,7 +65,7 @@ func (s *WorkerPoolEventService) Publish(topic string, event *events.NitricEvent
 		Event: evt,
 	})
 
-	fmt.Printf("Publishing event to: %s\n", targets)
+	fmt.Printf("Publishing to %s topic, %d subscriber(s)\n", topic, len(targets))
 	for _, target := range targets {
 		err = target.HandleEvent(evt)
 		if err != nil {


### PR DESCRIPTION
Updates the CLI output when publishing to local topic.

Current output:

<img width="651" alt="current-publish-output" src="https://user-images.githubusercontent.com/4121391/178777628-3efcdb54-4bfd-40f9-b7d2-eeef680d14e9.png">

New output:

<img width="510" alt="new-publish-output" src="https://user-images.githubusercontent.com/4121391/178777731-8d3a8f94-364c-4801-a7a5-00f4a29c196b.png">