### PR TITLE
fix: improve consistency of local run status outputs

### DIFF
--- a/pkg/cmd/run/root.go
+++ b/pkg/cmd/run/root.go
@@ -71,7 +71,7 @@ var runCmd = &cobra.Command{
 		}
 
 		codeAsConfig := tasklet.Runner{
-			StartMsg: "Gathering configuration from code..",
+			StartMsg: "Gathering configuration from code...",
 			Runner: func(_ output.Progress) error {
 				proj, err = codeconfig.Populate(proj, envMap)
 				return err
@@ -93,11 +93,11 @@ var runCmd = &cobra.Command{
 		cobra.CheckErr(logger.Start())
 
 		createBaseImage := tasklet.Runner{
-			StartMsg: "Creating Dev Image",
+			StartMsg: "Creating development image",
 			Runner: func(_ output.Progress) error {
 				return build.CreateBaseDev(proj)
 			},
-			StopMsg: "Created Dev Image!",
+			StopMsg: "Development image created",
 		}
 		tasklet.MustRun(createBaseImage, tasklet.Opts{Signal: term})
 
@@ -105,7 +105,7 @@ var runCmd = &cobra.Command{
 		pool := run.NewRunProcessPool()
 
 		startLocalServices := tasklet.Runner{
-			StartMsg: "Starting Local Services",
+			StartMsg: "Starting local services",
 			Runner: func(progress output.Progress) error {
 				go func(errch chan error) {
 					errch <- ls.Start(pool)
@@ -123,12 +123,12 @@ var runCmd = &cobra.Command{
 					if ls.Running() {
 						break
 					}
-					progress.Busyf("Waiting for Local Services to be ready")
+					progress.Busyf("Waiting for local services...")
 					time.Sleep(time.Second)
 				}
 				return nil
 			},
-			StopMsg: "Started Local Services!",
+			StopMsg: "Local services running",
 		}
 		tasklet.MustRun(startLocalServices, tasklet.Opts{
 			Signal: term,
@@ -137,7 +137,7 @@ var runCmd = &cobra.Command{
 		var functions []*run.Function
 
 		startFunctions := tasklet.Runner{
-			StartMsg: "Starting Functions",
+			StartMsg: "Starting functions",
 			Runner: func(_ output.Progress) error {
 				functions, err = run.FunctionsFromHandlers(proj)
 				if err != nil {
@@ -151,11 +151,11 @@ var runCmd = &cobra.Command{
 				}
 				return nil
 			},
-			StopMsg: "Started Functions!",
+			StopMsg: "Functions running",
 		}
 		tasklet.MustRun(startFunctions, tasklet.Opts{Signal: term})
 
-		pterm.DefaultBasicText.Println("Local running, use ctrl-C to stop")
+		pterm.DefaultBasicText.Println("Application running, use ctrl-C to stop")
 
 		stackState := run.NewStackState()
 


### PR DESCRIPTION
This PR has minor changes to the status messages printed when using the `run` command. They're intended to increase the consistency of the capitalization and format.

Current format:

<img width="297" alt="current-status-output" src="https://user-images.githubusercontent.com/4121391/178780497-31b33a91-02c1-4db3-85b8-6a55fe931a00.png">

New format:

<img width="414" alt="new-status-output" src="https://user-images.githubusercontent.com/4121391/178780539-fa5ca968-5f4b-449e-87c1-90763dbe589c.png">
