### PR TITLE
feat: improve the build time by placing the build inline in pulumi

### DIFF
--- a/.github/workflows/aws-e2e.yaml
+++ b/.github/workflows/aws-e2e.yaml
@@ -40,14 +40,15 @@ jobs:
           make build
           mv bin/nitric $(go env GOPATH)/bin/nitric
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: install-aws-cli
+        uses: unfor19/install-aws-cli-action@v1.0.3
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
+          arch: amd64
 
       - name: Nitric UP
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           cd ${{ github.workspace }}/test-app
           nitric up -s aws --ci
@@ -80,13 +81,10 @@ jobs:
             mv bin/nitric $(go env GOPATH)/bin/nitric
           fi
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
       - name: Nitric Down
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           cd ${{ github.workspace }}/test-app
           nitric down -s aws --ci -y

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/nitrictech/cli/mocks/mock_containerengine"
 	"github.com/nitrictech/cli/pkg/containerengine"
 	"github.com/nitrictech/cli/pkg/project"
-	"github.com/nitrictech/cli/pkg/stack"
 )
 
 func TestCreateBaseDev(t *testing.T) {
@@ -48,36 +47,6 @@ func TestCreateBaseDev(t *testing.T) {
 	containerengine.DiscoveredEngine = me
 
 	if err := CreateBaseDev(s); err != nil {
-		t.Errorf("CreateBaseDev() error = %v", err)
-	}
-}
-
-func TestCreate(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	me := mock_containerengine.NewMockContainerEngine(ctrl)
-	me.EXPECT().Build(gomock.Any(), ".", "test-stack--aws", map[string]string{"PROVIDER": "aws"}, []string{"node_modules/", ".nitric/", ".git/", ".idea/"})
-	me.EXPECT().Build("Dockerfile.custom", ".", "test-stack--aws", map[string]string{"PROVIDER": "aws"}, []string{})
-
-	containerengine.DiscoveredEngine = me
-
-	s := &project.Project{
-		Name: "test-stack",
-		Dir:  ".",
-		Functions: map[string]project.Function{
-			"list": {
-				Handler:     "functions/list.ts",
-				ComputeUnit: project.ComputeUnit{},
-			},
-		},
-		Containers: map[string]project.Container{
-			"doit": {
-				Dockerfile:  "Dockerfile.custom",
-				ComputeUnit: project.ComputeUnit{},
-			},
-		},
-	}
-
-	if err := Create(s, &stack.Config{Provider: "aws", Region: "eastus"}); err != nil {
 		t.Errorf("CreateBaseDev() error = %v", err)
 	}
 }

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -42,7 +42,8 @@ func TestCreateBaseDev(t *testing.T) {
 	s := project.New(&project.Config{Name: "", Dir: dir})
 	s.Functions = map[string]project.Function{"foo": {Handler: "functions/list.ts"}}
 
-	me.EXPECT().Build(gomock.Any(), dir, "nitric-ts-dev", map[string]string{}, []string{"node_modules/", ".nitric/", ".git/", ".idea/"})
+	me.EXPECT().Build(gomock.Any(), dir, "nitric-ts-dev", map[string]string{}, []string{
+		".nitric/", ".git/", ".idea/", ".vscode/", ".github", "node_modules/"})
 
 	containerengine.DiscoveredEngine = me
 

--- a/pkg/cmd/stack/root.go
+++ b/pkg/cmd/stack/root.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 
-	"github.com/nitrictech/cli/pkg/build"
 	"github.com/nitrictech/cli/pkg/codeconfig"
 	"github.com/nitrictech/cli/pkg/output"
 	"github.com/nitrictech/cli/pkg/project"
@@ -134,15 +133,6 @@ var stackUpdateCmd = &cobra.Command{
 
 		p, err := provider.NewProvider(proj, s, envMap, &types.ProviderOpts{Force: force})
 		cobra.CheckErr(err)
-
-		buildImages := tasklet.Runner{
-			StartMsg: "Building Images",
-			Runner: func(_ output.Progress) error {
-				return build.Create(proj, s)
-			},
-			StopMsg: "Images built",
-		}
-		tasklet.MustRun(buildImages, tasklet.Opts{})
 
 		d := &types.Deployment{}
 		deploy := tasklet.Runner{

--- a/pkg/provider/pulumi/aws/aws.go
+++ b/pkg/provider/pulumi/aws/aws.go
@@ -291,7 +291,9 @@ func (a *awsProvider) Deploy(ctx *pulumi.Context) error {
 		image, ok := a.images[c.Unit().Name]
 		if !ok {
 			image, err = common.NewImage(ctx, c.Unit().Name, &common.ImageArgs{
-				LocalImageName:  localImageName,
+				ProjectDir:      a.proj.Dir,
+				Provider:        a.sc.Provider,
+				Compute:         c,
 				SourceImageName: c.ImageTagName(a.proj, a.sc.Provider),
 				RepositoryUrl:   repo.RepositoryUrl,
 				Server:          pulumi.String(authToken.ProxyEndpoint),

--- a/pkg/provider/pulumi/azure/containerapp.go
+++ b/pkg/provider/pulumi/azure/containerapp.go
@@ -182,11 +182,12 @@ func (a *azureProvider) newContainerApps(ctx *pulumi.Context, name string, args 
 	}).(pulumi.StringPtrOutput)
 
 	for _, c := range a.proj.Computes() {
-		localImageName := c.ImageTagName(a.proj, "")
 		repositoryUrl := pulumi.Sprintf("%s/%s", res.Registry.LoginServer, c.ImageTagName(a.proj, a.sc.Provider))
 
 		image, err := common.NewImage(ctx, c.Unit().Name+"Image", &common.ImageArgs{
-			LocalImageName:  localImageName,
+			ProjectDir:      a.proj.Dir,
+			Provider:        a.sc.Provider,
+			Compute:         c,
 			SourceImageName: c.ImageTagName(a.proj, a.sc.Provider),
 			RepositoryUrl:   repositoryUrl,
 			Username:        adminUser.Elem(),

--- a/pkg/provider/pulumi/common/build.go
+++ b/pkg/provider/pulumi/common/build.go
@@ -17,7 +17,10 @@
 package common
 
 import (
+	"errors"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/nitrictech/cli/pkg/project"
 	"github.com/nitrictech/cli/pkg/runtime"
@@ -48,6 +51,13 @@ func dockerfile(tempDir, projDir, provider string, c project.Compute) (string, e
 		err = rt.FunctionDockerfile(projDir, project.DefaultMembraneVersion, provider, fh)
 		if err != nil {
 			return "", err
+		}
+
+		if _, err := os.Stat(filepath.Join(projDir, ".dockerignore")); errors.Is(err, os.ErrNotExist) {
+			err = os.WriteFile(filepath.Join(projDir, ".dockerignore"), []byte(strings.Join(rt.BuildIgnore(), "\n")), 0600)
+			if err != nil {
+				return "", err
+			}
 		}
 
 		fh.Close()

--- a/pkg/provider/pulumi/common/build.go
+++ b/pkg/provider/pulumi/common/build.go
@@ -1,0 +1,59 @@
+// Copyright Nitric Pty Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"os"
+
+	"github.com/nitrictech/cli/pkg/project"
+	"github.com/nitrictech/cli/pkg/runtime"
+	"github.com/nitrictech/cli/pkg/utils"
+)
+
+func dynamicDockerfile(dir, name string) (*os.File, error) {
+	// create a more stable file name for the hashing
+	return os.CreateTemp(dir, "nitric."+name+".Dockerfile.*")
+}
+
+func dockerfile(tempDir, projDir, provider string, c project.Compute) (string, error) {
+	switch x := c.(type) {
+	case *project.Container:
+		return x.Dockerfile, nil
+
+	case *project.Function:
+		fh, err := dynamicDockerfile(tempDir, x.Name)
+		if err != nil {
+			return "", err
+		}
+
+		rt, err := runtime.NewRunTimeFromHandler(x.Handler)
+		if err != nil {
+			return "", err
+		}
+
+		err = rt.FunctionDockerfile(projDir, project.DefaultMembraneVersion, provider, fh)
+		if err != nil {
+			return "", err
+		}
+
+		fh.Close()
+
+		return fh.Name(), nil
+	}
+
+	return "", utils.NewNotSupportedErr("only Function and Containers supported")
+}

--- a/pkg/provider/pulumi/common/build_test.go
+++ b/pkg/provider/pulumi/common/build_test.go
@@ -1,0 +1,96 @@
+// Copyright Nitric Pty Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/nitrictech/cli/pkg/project"
+)
+
+func TestDockerfile(t *testing.T) {
+	tests := []struct {
+		name     string
+		c        project.Compute
+		want     string
+		wantBody string
+		wantErr  error
+	}{
+		{
+			name: "function",
+			c: &project.Function{
+				Handler:     "functions/list.ts",
+				ComputeUnit: project.ComputeUnit{Name: "list"},
+			},
+			want: "nitric.list.Dockerfile",
+			wantBody: `FROM node:alpine as layer-build
+RUN yarn global add typescript @vercel/ncc
+COPY package.json *.lock *-lock.json /
+RUN yarn import || echo Lockfile already exists
+RUN set -ex; yarn install --production --frozen-lockfile --cache-folder /tmp/.cache; rm -rf /tmp/.cache;
+COPY . .
+RUN test -f tsconfig.json || echo '{"compilerOptions":{"esModuleInterop":true,"target":"es2015","moduleResolution":"node"}}' > tsconfig.json
+RUN ncc build functions/list.ts -m --v8-cache -o lib/
+FROM node:alpine as layer-final
+COPY --from=layer-build package.json package.json
+COPY --from=layer-build node_modules/ node_modules/
+COPY --from=layer-build lib/ /
+ADD https://github.com/nitrictech/nitric/releases/download/v0.17.0/membrane-aws /usr/local/bin/membrane
+RUN chmod +x-rw /usr/local/bin/membrane
+ENTRYPOINT ["/usr/local/bin/membrane"]
+CMD ["node", "index.js"]`,
+		},
+		{
+			name: "container",
+			c: &project.Container{
+				Dockerfile:  "Dockerfile.custom",
+				ComputeUnit: project.ComputeUnit{Name: "custom"},
+			},
+			want: "Dockerfile.custom",
+		},
+	}
+
+	td := t.TempDir()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fn, err := dockerfile(td, ".", "aws", tt.c)
+			if (err != nil) != (tt.wantErr != nil) {
+				t.Errorf("dockerfile() error = %v", err)
+			}
+
+			if !strings.Contains(fn, tt.want) {
+				t.Errorf("%s != %s", tt.want, fn)
+			}
+
+			if tt.wantBody != "" {
+				contents, err := os.ReadFile(fn)
+				if err != nil {
+					t.Error(err)
+				}
+
+				if !cmp.Equal(tt.wantBody, string(contents)) {
+					t.Error(cmp.Diff(tt.wantBody, string(contents)))
+				}
+			}
+		})
+	}
+}

--- a/pkg/provider/pulumi/common/build_test.go
+++ b/pkg/provider/pulumi/common/build_test.go
@@ -91,6 +91,8 @@ CMD ["node", "index.js"]`,
 					t.Error(cmp.Diff(tt.wantBody, string(contents)))
 				}
 			}
+
+			_ = os.Remove(".dockerignore")
 		})
 	}
 }

--- a/pkg/provider/pulumi/common/image.go
+++ b/pkg/provider/pulumi/common/image.go
@@ -17,15 +17,17 @@
 package common
 
 import (
-	"io/ioutil"
-
 	"github.com/pulumi/pulumi-docker/sdk/v3/go/docker"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"github.com/nitrictech/cli/pkg/project"
 )
 
 type ImageArgs struct {
-	LocalImageName  string
+	ProjectDir      string
+	Provider        string
 	SourceImageName string
+	Compute         project.Compute
 	RepositoryUrl   pulumi.StringInput
 	TempDir         string
 	Server          pulumi.StringInput
@@ -48,12 +50,7 @@ func NewImage(ctx *pulumi.Context, name string, args *ImageArgs, opts ...pulumi.
 		return nil, err
 	}
 
-	dummyDockerFilePath, err := ioutil.TempFile(args.TempDir, "*.dockerfile")
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = dummyDockerFilePath.WriteString("FROM " + args.SourceImageName + "\n")
+	dockerFilePath, err := dockerfile(args.TempDir, args.ProjectDir, args.Provider, args.Compute)
 	if err != nil {
 		return nil, err
 	}
@@ -61,10 +58,13 @@ func NewImage(ctx *pulumi.Context, name string, args *ImageArgs, opts ...pulumi.
 	imageArgs := &docker.ImageArgs{
 		ImageName: args.RepositoryUrl,
 		Build: docker.DockerBuildArgs{
+			CacheFrom: docker.CacheFromPtr(&docker.CacheFromArgs{}),
+			Context:   pulumi.String(args.ProjectDir),
+			Args:      pulumi.StringMap{"PROVIDER": pulumi.String(args.Provider)},
 			Env: pulumi.StringMap{
 				"DOCKER_BUILDKIT": pulumi.String("1"),
 			},
-			Dockerfile: pulumi.String(dummyDockerFilePath.Name()),
+			Dockerfile: pulumi.String(dockerFilePath),
 		},
 		Registry: docker.ImageRegistryArgs{
 			Server:   args.Server,

--- a/pkg/provider/pulumi/common/image.go
+++ b/pkg/provider/pulumi/common/image.go
@@ -58,9 +58,13 @@ func NewImage(ctx *pulumi.Context, name string, args *ImageArgs, opts ...pulumi.
 	imageArgs := &docker.ImageArgs{
 		ImageName: args.RepositoryUrl,
 		Build: docker.DockerBuildArgs{
-			CacheFrom: docker.CacheFromPtr(&docker.CacheFromArgs{}),
-			Context:   pulumi.String(args.ProjectDir),
-			Args:      pulumi.StringMap{"PROVIDER": pulumi.String(args.Provider)},
+			CacheFrom: docker.CacheFromPtr(&docker.CacheFromArgs{
+				Stages: pulumi.StringArray{
+					pulumi.String("layer-build"),
+					pulumi.String("layer-final"),
+				}}),
+			Context: pulumi.String(args.ProjectDir),
+			Args:    pulumi.StringMap{"PROVIDER": pulumi.String(args.Provider)},
 			Env: pulumi.StringMap{
 				"DOCKER_BUILDKIT": pulumi.String("1"),
 			},

--- a/pkg/provider/pulumi/gcp/gcp.go
+++ b/pkg/provider/pulumi/gcp/gcp.go
@@ -375,7 +375,9 @@ func (g *gcpProvider) Deploy(ctx *pulumi.Context) error {
 	for _, c := range g.proj.Computes() {
 		if _, ok := g.images[c.Unit().Name]; !ok {
 			g.images[c.Unit().Name], err = common.NewImage(ctx, c.Unit().Name+"Image", &common.ImageArgs{
-				LocalImageName:  c.ImageTagName(g.proj, ""),
+				ProjectDir:      g.proj.Dir,
+				Provider:        g.sc.Provider,
+				Compute:         c,
 				SourceImageName: c.ImageTagName(g.proj, g.sc.Provider),
 				RepositoryUrl:   pulumi.Sprintf("gcr.io/%s/%s", g.projectId, c.ImageTagName(g.proj, g.sc.Provider)),
 				Username:        pulumi.String("oauth2accesstoken"),

--- a/pkg/runtime/javascript.go
+++ b/pkg/runtime/javascript.go
@@ -36,7 +36,7 @@ type javascript struct {
 
 var (
 	_                    Runtime = &javascript{}
-	javascriptIgnoreList         = []string{"node_modules/", ".nitric/", ".git/", ".idea/"}
+	javascriptIgnoreList         = append(commonIgnore, "node_modules/")
 )
 
 func (t *javascript) DevImageName() string {
@@ -52,8 +52,11 @@ func (t *javascript) BuildIgnore() []string {
 }
 
 func (t *javascript) FunctionDockerfile(funcCtxDir, version, provider string, w io.Writer) error {
-	con, err := dockerfile.NewContainer(dockerfile.NewContainerOpts{
+	css := dockerfile.NewStateStore()
+
+	con, err := css.NewContainer(dockerfile.NewContainerOpts{
 		From:   "node:alpine",
+		As:     layerFinal, // no build stage in this
 		Ignore: javascriptIgnoreList,
 	})
 	if err != nil {

--- a/pkg/runtime/python.go
+++ b/pkg/runtime/python.go
@@ -42,7 +42,7 @@ func (t *python) ContainerName() string {
 }
 
 func (t *python) BuildIgnore() []string {
-	return []string{"__pycache__/", "*.py[cod]", "*$py.class"}
+	return append(commonIgnore, "__pycache__/", "*.py[cod]", "*$py.class")
 }
 
 func (t *python) FunctionDockerfileForCodeAsConfig(w io.Writer) error {
@@ -58,8 +58,11 @@ func (t *python) LaunchOptsForFunction(runCtx string) (LaunchOpts, error) {
 }
 
 func (t *python) FunctionDockerfile(funcCtxDir, version, provider string, w io.Writer) error {
-	con, err := dockerfile.NewContainer(dockerfile.NewContainerOpts{
+	css := dockerfile.NewStateStore()
+
+	con, err := css.NewContainer(dockerfile.NewContainerOpts{
 		From:   "python:3.7-slim",
+		As:     layerFinal,
 		Ignore: t.BuildIgnore(),
 	})
 	if err != nil {

--- a/pkg/runtime/types.go
+++ b/pkg/runtime/types.go
@@ -49,6 +49,13 @@ const (
 	RuntimeJava       RuntimeExt = "java"
 
 	RuntimeUnknown RuntimeExt = ""
+
+	layerBuild = "build"
+	layerFinal = "final"
+)
+
+var (
+	commonIgnore = []string{".nitric/", ".git/", ".idea/", ".vscode/", ".github"}
 )
 
 type LaunchOpts struct {

--- a/pkg/runtime/typescript.go
+++ b/pkg/runtime/typescript.go
@@ -54,7 +54,7 @@ func (t *typescript) FunctionDockerfile(funcCtxDir, version, provider string, w 
 	// Start build stage
 	buildstage, err := css.NewContainer(dockerfile.NewContainerOpts{
 		From:   "node:alpine",
-		As:     "build",
+		As:     layerBuild,
 		Ignore: javascriptIgnoreList,
 	})
 	if err != nil {
@@ -86,7 +86,7 @@ func (t *typescript) FunctionDockerfile(funcCtxDir, version, provider string, w 
 	// start final stage
 	con, err := css.NewContainer(dockerfile.NewContainerOpts{
 		From:   "node:alpine",
-		As:     "final",
+		As:     layerFinal,
 		Ignore: javascriptIgnoreList,
 	})
 	if err != nil {


### PR DESCRIPTION
part of: https://github.com/nitrictech/pro-backend/issues/166

Currently the images are built first with local names (not including any repo as they are not know)
This means that when running "up" from a new machine the images will not be present. and nothing
will be cached. This PR moves the image building directly into pulumi so that the images are pulled
by pulumi before building.
