### PR TITLE
AWS: Re-enable autonaming for SNS topics.

### DIFF
--- a/pkg/provider/pulumi/aws/aws.go
+++ b/pkg/provider/pulumi/aws/aws.go
@@ -193,9 +193,6 @@ func (a *awsProvider) Deploy(ctx *pulumi.Context) error {
 
 	for k := range a.proj.Topics {
 		a.topics[k], err = sns.NewTopic(ctx, k, &sns.TopicArgs{
-			// FIXME: Autonaming of topics disabled until improvements to
-			// nitric topic name discovery is made for SNS topics.
-			Name: pulumi.StringPtr(k),
 			Tags: common.Tags(ctx, k),
 		})
 		if err != nil {


### PR DESCRIPTION
Re-enable autonaming for SNS topics for deployments.

Have checked both the AWS gateway and SNS plugin implementations and both are using new tag based discovery.