### PR TITLE
fix: revert image build option "cache-from" as it is slowing down builds

### DIFF
--- a/pkg/provider/pulumi/common/image.go
+++ b/pkg/provider/pulumi/common/image.go
@@ -58,11 +58,12 @@ func NewImage(ctx *pulumi.Context, name string, args *ImageArgs, opts ...pulumi.
 	imageArgs := &docker.ImageArgs{
 		ImageName: args.RepositoryUrl,
 		Build: docker.DockerBuildArgs{
-			CacheFrom: docker.CacheFromPtr(&docker.CacheFromArgs{
-				Stages: pulumi.StringArray{
-					pulumi.String("layer-build"),
-					pulumi.String("layer-final"),
-				}}),
+			// This below is slowing done builds significantly.
+			//CacheFrom: docker.CacheFromPtr(&docker.CacheFromArgs{
+			//	Stages: pulumi.StringArray{
+			//		pulumi.String("layer-build"),
+			//		pulumi.String("layer-final"),
+			//	}}),
 			Context: pulumi.String(args.ProjectDir),
 			Args:    pulumi.StringMap{"PROVIDER": pulumi.String(args.Provider)},
 			Env: pulumi.StringMap{


### PR DESCRIPTION
This should help with projects that have lots of updated, but when doing a create it is slower as it has to push 2 extra images. 