### PR TITLE
Add stack digest side logging to up and down.

### DIFF
--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -17,7 +17,6 @@
 package build
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -32,7 +31,7 @@ func TestCreateBaseDev(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	me := mock_containerengine.NewMockContainerEngine(ctrl)
 
-	dir, err := ioutil.TempDir("", "test-nitric-build")
+	dir, err := os.MkdirTemp("", "test-nitric-build")
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/cron/cron.go
+++ b/pkg/cron/cron.go
@@ -120,7 +120,8 @@ func ConvertToAWS(schedule string) (string, error) {
 
 // toRate converts a cron "@every" directive to a rate expression defined in minutes.
 // example input: @every 1h30m
-//        output: rate(90 minutes)
+//
+//	output: rate(90 minutes)
 func toRate(duration string) (string, error) {
 	d, err := time.ParseDuration(duration)
 	if err != nil {
@@ -146,9 +147,10 @@ func toRate(duration string) (string, error) {
 // toFixedSchedule converts cron predefined schedules into AWS-flavored cron expressions.
 // (https://godoc.org/github.com/robfig/cron#hdr-Predefined_schedules)
 // Example input: @daily
-//        output: cron(0 0 * * ? *)
-//         input: @annually
-//        output: cron(0 0 1 1 ? *)
+//
+//	output: cron(0 0 * * ? *)
+//	 input: @annually
+//	output: cron(0 0 1 1 ? *)
 func toFixedSchedule(schedule string) (string, error) {
 	switch {
 	case strings.HasPrefix(schedule, hourly):
@@ -181,7 +183,8 @@ func awsCronFieldSpecified(input string) bool {
 // BOTH DOM and DOW cannot be specified
 // DOW numbers run 1-7, not 0-6
 // Example input: 0 9 * * 1-5 (at 9 am, Monday-Friday)
-//              : cron(0 9 ? * 2-6 *) (adds required ? operator, increments DOW to 1-index, adds year)
+//
+//	: cron(0 9 ? * 2-6 *) (adds required ? operator, increments DOW to 1-index, adds year)
 func toAWSCron(schedule string) (string, error) {
 	const (
 		MIN = iota

--- a/pkg/output/format.go
+++ b/pkg/output/format.go
@@ -229,12 +229,12 @@ func printMap(object interface{}, out io.Writer) {
 }
 
 // printStruct will print something like the following:
-//+------------+--------------------------------+
-//| ID         | 6e83378b322a                   |
-//| REPOSITORY | go-create-local                |
-//| TAG        | latest                         |
-//| CREATEDAT  | 2022-01-07 15:19:01 +1000 AEST |
-//+------------+--------------------------------+
+// +------------+--------------------------------+
+// | ID         | 6e83378b322a                   |
+// | REPOSITORY | go-create-local                |
+// | TAG        | latest                         |
+// | CREATEDAT  | 2022-01-07 15:19:01 +1000 AEST |
+// +------------+--------------------------------+
 func printStruct(object interface{}, out io.Writer) {
 	tab := table.NewWriter()
 	tab.SetOutputMirror(out)

--- a/pkg/project/config.go
+++ b/pkg/project/config.go
@@ -17,7 +17,6 @@
 package project
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -41,7 +40,7 @@ func (p *Config) ToFile() error {
 		return err
 	}
 
-	return ioutil.WriteFile(filepath.Join(p.Dir, "nitric.yaml"), b, 0644)
+	return os.WriteFile(filepath.Join(p.Dir, "nitric.yaml"), b, 0644)
 }
 
 // ConfigFromProjectPath - loads the config nitric.yaml file from the project path, defaults to the current working directory
@@ -64,7 +63,7 @@ func ConfigFromProjectPath(projPath string) (*Config, error) {
 		Dir: absDir,
 	}
 
-	yamlFile, err := ioutil.ReadFile(filepath.Join(projPath, "nitric.yaml"))
+	yamlFile, err := os.ReadFile(filepath.Join(projPath, "nitric.yaml"))
 	if err != nil {
 		return nil, errors.WithMessage(err, "No nitric project found (unable to find nitric.yaml). If you haven't created a project yet, run `nitric new` to get started")
 	}

--- a/pkg/project/types.go
+++ b/pkg/project/types.go
@@ -19,7 +19,7 @@ package project
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 
@@ -276,7 +276,7 @@ func calculateDefaultPolicies(s *Project) []*v1.PolicyResource {
 }
 
 func FromFile(name string) (*Project, error) {
-	yamlFile, err := ioutil.ReadFile(name)
+	yamlFile, err := os.ReadFile(name)
 	if err != nil {
 		return nil, err
 	}
@@ -328,7 +328,7 @@ func (s *Project) ToFile(file string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(file, b, 0644)
+	err = os.WriteFile(file, b, 0644)
 	if err != nil {
 		return err
 	}
@@ -346,7 +346,7 @@ func (s *Project) ToFile(file string) error {
 			return err
 		}
 
-		err = ioutil.WriteFile(apiPath, docJ, 0644)
+		err = os.WriteFile(apiPath, docJ, 0644)
 		if err != nil {
 			return err
 		}

--- a/pkg/provider/pulumi/aws/aws.go
+++ b/pkg/provider/pulumi/aws/aws.go
@@ -23,7 +23,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -164,7 +163,7 @@ func policyResourceName(policy *v1.PolicyResource) (string, error) {
 func (a *awsProvider) Deploy(ctx *pulumi.Context) error {
 	var err error
 
-	a.tmpDir, err = ioutil.TempDir("", ctx.Stack()+"-*")
+	a.tmpDir, err = os.MkdirTemp("", ctx.Stack()+"-*")
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/pulumi/azure/azure.go
+++ b/pkg/provider/pulumi/azure/azure.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -198,7 +197,7 @@ func (a *azureProvider) Configure(ctx context.Context, autoStack *auto.Stack) er
 func (a *azureProvider) Deploy(ctx *pulumi.Context) error {
 	var err error
 
-	a.tmpDir, err = ioutil.TempDir("", ctx.Stack()+"-*")
+	a.tmpDir, err = os.MkdirTemp("", ctx.Stack()+"-*")
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/pulumi/gcp/gateway.go
+++ b/pkg/provider/pulumi/gcp/gateway.go
@@ -20,7 +20,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -83,7 +83,7 @@ func getOpenIdConnectConfig(issuer string) (*openIdConfig, error) {
 		return nil, fmt.Errorf("received non 200 status retrieving openid-configuration: %d", resp.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/pulumi/gcp/gcp.go
+++ b/pkg/provider/pulumi/gcp/gcp.go
@@ -24,7 +24,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -226,7 +225,7 @@ func (g *gcpProvider) setToken() error {
 func (g *gcpProvider) Deploy(ctx *pulumi.Context) error {
 	var err error
 
-	g.tmpDir, err = ioutil.TempDir("", ctx.Stack()+"-*")
+	g.tmpDir, err = os.MkdirTemp("", ctx.Stack()+"-*")
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/pulumi/logger.go
+++ b/pkg/provider/pulumi/logger.go
@@ -1,11 +1,28 @@
+// Copyright Nitric Pty Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package pulumi
 
 import (
 	"fmt"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/events"
+
 	"github.com/nitrictech/cli/pkg/output"
 	"github.com/nitrictech/cli/pkg/provider/types"
-	"github.com/pulumi/pulumi/sdk/v3/go/auto/events"
 )
 
 // Use to collect summary from pulumi stack updates

--- a/pkg/provider/pulumi/logger.go
+++ b/pkg/provider/pulumi/logger.go
@@ -1,0 +1,50 @@
+package pulumi
+
+import (
+	"fmt"
+
+	"github.com/nitrictech/cli/pkg/output"
+	"github.com/nitrictech/cli/pkg/provider/types"
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/events"
+)
+
+// Use to collect summary from pulumi stack updates
+type pulumiLogger struct {
+	resources map[string]*types.ResourceState
+
+	output.Progress
+}
+
+func (p *pulumiLogger) getResourceState(urn string) *types.ResourceState {
+	if p.resources[urn] == nil {
+		p.resources[urn] = &types.ResourceState{
+			Errored:  false,
+			Messages: make([]string, 0),
+		}
+	}
+
+	return p.resources[urn]
+}
+
+func (p *pulumiLogger) CollectEvent(evt events.EngineEvent) {
+	if p.resources == nil {
+		p.resources = map[string]*types.ResourceState{}
+	}
+
+	if evt.DiagnosticEvent != nil && evt.DiagnosticEvent.URN != "" {
+		rs := p.getResourceState(evt.DiagnosticEvent.URN)
+
+		rs.Messages = append(rs.Messages, evt.DiagnosticEvent.Message)
+	}
+
+	if evt.ResOpFailedEvent != nil {
+		rs := p.getResourceState(evt.ResOpFailedEvent.Metadata.URN)
+		rs.Errored = true
+		rs.OpType = fmt.Sprintf("%s", evt.ResOpFailedEvent.Metadata.Op)
+	}
+
+	if evt.ResOutputsEvent != nil {
+		rs := p.getResourceState(evt.ResOutputsEvent.Metadata.URN)
+		rs.OpType = fmt.Sprintf("%s", evt.ResOutputsEvent.Metadata.Op)
+	}
+}

--- a/pkg/provider/pulumi/logging.go
+++ b/pkg/provider/pulumi/logging.go
@@ -31,7 +31,7 @@ import (
 	"github.com/nitrictech/cli/pkg/output"
 )
 
-func updateLoggingOpts(log output.Progress) []optup.Option {
+func updateLoggingOpts(log *pulumiLogger) []optup.Option {
 	upChannel := make(chan events.EngineEvent)
 	opts := []optup.Option{
 		optup.EventStreams(upChannel),
@@ -60,7 +60,7 @@ func updateLoggingOpts(log output.Progress) []optup.Option {
 	return opts
 }
 
-func destroyLoggingOpts(log output.Progress) []optdestroy.Option {
+func destroyLoggingOpts(log *pulumiLogger) []optdestroy.Option {
 	upChannel := make(chan events.EngineEvent)
 	opts := []optdestroy.Option{
 		optdestroy.EventStreams(upChannel),
@@ -100,7 +100,7 @@ func stepEventToString(eType string, evt *apitype.StepEventMetadata) string {
 
 const busyMsg = "%s %d/%d resources (%d failed)"
 
-func collectEvents(log output.Progress, eventChannel <-chan events.EngineEvent, prefix string) {
+func collectEvents(log *pulumiLogger, eventChannel <-chan events.EngineEvent, prefix string) {
 	busyList := map[string]time.Time{}
 
 	busy := 0
@@ -117,6 +117,8 @@ func collectEvents(log output.Progress, eventChannel <-chan events.EngineEvent, 
 		if !ok {
 			return
 		}
+
+		log.CollectEvent(event)
 
 		if event.ResourcePreEvent != nil && event.ResourcePreEvent.Metadata.Op != apitype.OpSame {
 			busy++

--- a/pkg/provider/types/interface.go
+++ b/pkg/provider/types/interface.go
@@ -21,7 +21,18 @@ import (
 	"github.com/nitrictech/cli/pkg/stack"
 )
 
+type ResourceState struct {
+	OpType   string
+	Errored  bool
+	Messages []string
+}
+
+type Summary struct {
+	Resources map[string]*ResourceState
+}
+
 type Deployment struct {
+	Summary      *Summary
 	ApiEndpoints map[string]string `json:"apiEndpoints,omitempty"`
 }
 
@@ -31,7 +42,7 @@ type ProviderOpts struct {
 
 type Provider interface {
 	Up(log output.Progress) (*Deployment, error)
-	Down(log output.Progress) error
+	Down(log output.Progress) (*Summary, error)
 	List() (interface{}, error)
 	Ask() (*stack.Config, error)
 	SupportedRegions() []string

--- a/pkg/stack/options.go
+++ b/pkg/stack/options.go
@@ -18,7 +18,7 @@ package stack
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -41,13 +41,13 @@ func (p *Config) ToFile(file string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(file, b, 0644)
+	return os.WriteFile(file, b, 0644)
 }
 
 func configFromFile(file string) (*Config, error) {
 	s := &Config{}
 
-	yamlFile, err := ioutil.ReadFile(file)
+	yamlFile, err := os.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("no nitric stack found (unable to find %s). If you haven't created a stack yet, run `nitric stack new` to get started", file)
 	}

--- a/pkg/utils/errors.go
+++ b/pkg/utils/errors.go
@@ -25,7 +25,9 @@ import (
 // because it is unsupported.
 // Functions and methods should not return this error but should instead
 // return an error including appropriate context that satisfies
-//     errors.Is(err, errors.NotSupportedError)
+//
+//	errors.Is(err, errors.NotSupportedError)
+//
 // either by directly wrapping NotSupportedError or by implementing an Is method.
 type NotSupportedError struct {
 	error

--- a/pkg/utils/paths.go
+++ b/pkg/utils/paths.go
@@ -20,6 +20,7 @@ import (
 	"go/build"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -37,8 +38,8 @@ func SplitPath(p string) []string {
 	return strings.FieldsFunc(p, slashSplitter)
 }
 
-// homeDir gets the nitric home directory
-func homeDir() string {
+// NitricHomeDir gets the nitric home directory
+func NitricHomeDir() string {
 	nitricHomeEnv := os.Getenv("NITRIC_HOME")
 	if nitricHomeEnv != "" {
 		return nitricHomeEnv
@@ -54,12 +55,25 @@ func homeDir() string {
 
 // NitricRunDir returns the directory to place runtime data.
 func NitricRunDir() string {
-	return filepath.Join(homeDir(), "run")
+	return filepath.Join(NitricHomeDir(), "run")
 }
 
 // NitricTemplatesDir returns the directory to place template related data.
 func NitricTemplatesDir() string {
-	return filepath.Join(homeDir(), "store")
+	return filepath.Join(NitricHomeDir(), "store")
+}
+
+func NitricStacksDir() (string, error) {
+	homeDir := NitricHomeDir()
+	stacksDir := path.Join(homeDir, "stacks")
+
+	// ensure .nitric exists
+	err := os.MkdirAll(stacksDir, os.ModePerm)
+	if err != nil {
+		return "", err
+	}
+
+	return stacksDir, nil
 }
 
 // NitricConfigDir returns the directory to find configuration.
@@ -73,11 +87,11 @@ func NitricConfigDir() string {
 		return filepath.Join(dirname, ".config", "nitric")
 	}
 
-	return homeDir()
+	return NitricHomeDir()
 }
 
 func NitricPreferencesPath() string {
-	return filepath.Join(homeDir(), ".user-preferences.json")
+	return filepath.Join(NitricHomeDir(), ".user-preferences.json")
 }
 
 // NitricLogDir returns the directory to find log files.


### PR DESCRIPTION
The intention with this is to allow to CLI to sidelog stack state for easier parsing than the default output logs

Sample output for deleting a stack that has a bucket containing files:
```json
{
    "Resources": {
        "urn:pulumi:bucket-test-aws::bucket-test::aws:ecr/repository:Repository::bucket-test-hello": {
            "OpType": "delete",
            "Errored": false,
            "Messages": []
        },
        "urn:pulumi:bucket-test-aws::bucket-test::aws:resourcegroups/group:Group::bucket-test-aws": {
            "OpType": "delete",
            "Errored": false,
            "Messages": []
        },
        "urn:pulumi:bucket-test-aws::bucket-test::aws:s3/bucket:Bucket::test": {
            "OpType": "delete",
            "Errored": true,
            "Messages": [
                "deleting urn:pulumi:bucket-test-aws::bucket-test::aws:s3/bucket:Bucket::test: 1 error occurred:\n\t* error deleting S3 Bucket (test-6e423d5): BucketNotEmpty: The bucket you tried to delete is not empty\n\tstatus code: 409, request id: YXMB566WPKSD37M4, host id: 5DrXMPi1yxClUPUr5aiTgScU/UwKb8LBVxEFNbpnFJaoISKXfugPcM3FGt8dN+w6GlfgTtBr/sA=\n\n\n"
            ]
        },
        "urn:pulumi:bucket-test-aws::bucket-test::nitric:api:AwsApiGateway$aws:apigatewayv2/api:Api::main": {
            "OpType": "delete",
            "Errored": false,
            "Messages": []
        },
        "urn:pulumi:bucket-test-aws::bucket-test::nitric:api:AwsApiGateway$aws:apigatewayv2/stage:Stage::mainDefaultStage": {
            "OpType": "delete",
            "Errored": false,
            "Messages": []
        },
        "urn:pulumi:bucket-test-aws::bucket-test::nitric:api:AwsApiGateway$aws:lambda/permission:Permission::mainhello": {
            "OpType": "delete",
            "Errored": false,
            "Messages": []
        },
        "urn:pulumi:bucket-test-aws::bucket-test::nitric:func:AWSLambda$aws:iam/role:Role::helloLambdaRole": {
            "OpType": "delete",
            "Errored": false,
            "Messages": []
        },
        "urn:pulumi:bucket-test-aws::bucket-test::nitric:func:AWSLambda$aws:iam/rolePolicy:RolePolicy::helloListAccess": {
            "OpType": "delete",
            "Errored": false,
            "Messages": []
        },
        "urn:pulumi:bucket-test-aws::bucket-test::nitric:func:AWSLambda$aws:iam/rolePolicyAttachment:RolePolicyAttachment::helloLambdaBasicExecution": {
            "OpType": "delete",
            "Errored": false,
            "Messages": []
        },
        "urn:pulumi:bucket-test-aws::bucket-test::nitric:func:AWSLambda$aws:lambda/function:Function::hello": {
            "OpType": "delete",
            "Errored": false,
            "Messages": []
        },
        "urn:pulumi:bucket-test-aws::bucket-test::nitric:policy:AWSPolicyRoles$aws:iam/rolePolicy:RolePolicy::hello-32dbbb025e719df544a72ad6f448b163": {
            "OpType": "delete",
            "Errored": false,
            "Messages": []
        }
    }
}
```