### PR TITLE
Install pass by default in image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update -y && \
   gnupg \
   software-properties-common \
   wget \
+  pass \
   unzip && \
   # Get all of the signatures we need all at once.
   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key  | apt-key add - && \


### PR DESCRIPTION
See docker credential store default behaviour:
https://docs.docker.com/engine/reference/commandline/login/#credentials-store