### PR TITLE
feat: pass stack config through to pulumi providers

### DIFF
--- a/hack/allmods/main.go
+++ b/hack/allmods/main.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/golangci/golangci-lint/pkg/sliceutil"
+	"golang.org/x/exp/slices"
 	"golang.org/x/mod/modfile"
 )
 
@@ -41,7 +41,7 @@ func main() {
 	mods := []string{}
 
 	for _, r := range mf.Require {
-		if sliceutil.Contains(ignoreList, r.Mod.Path) {
+		if slices.Contains(ignoreList, r.Mod.Path) {
 			continue
 		}
 

--- a/pkg/cmd/stack/root.go
+++ b/pkg/cmd/stack/root.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path"
-	"path/filepath"
 	"runtime"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -89,21 +88,18 @@ var newStackCmd = &cobra.Command{
 		pName := ""
 		err = survey.AskOne(&survey.Select{
 			Message: "Which Cloud do you wish to deploy to?",
-			Default: stack.Aws,
-			Options: stack.Providers,
+			Default: types.Aws,
+			Options: types.Providers,
 		}, &pName)
 		cobra.CheckErr(err)
 
 		pc, err := project.ConfigFromProjectPath("")
 		cobra.CheckErr(err)
 
-		prov, err := provider.NewProvider(project.New(pc), &stack.Config{Name: name, Provider: pName}, map[string]string{}, &types.ProviderOpts{})
+		prov, err := provider.NewProvider(project.New(pc), name, pName, map[string]string{}, &types.ProviderOpts{})
 		cobra.CheckErr(err)
 
-		sc, err := prov.Ask()
-		cobra.CheckErr(err)
-
-		err = sc.ToFile(filepath.Join(pc.Dir, fmt.Sprintf("nitric-%s.yaml", sc.Name)))
+		err = prov.AskAndSave()
 		cobra.CheckErr(err)
 	},
 	Args:        cobra.MaximumNArgs(2),
@@ -175,7 +171,7 @@ var stackUpdateCmd = &cobra.Command{
 		}
 		tasklet.MustRun(codeAsConfig, tasklet.Opts{})
 
-		p, err := provider.NewProvider(proj, s, envMap, &types.ProviderOpts{Force: force})
+		p, err := provider.NewProvider(proj, s.Name, s.Provider, envMap, &types.ProviderOpts{Force: force})
 		cobra.CheckErr(err)
 
 		d := &types.Deployment{}
@@ -236,7 +232,7 @@ nitric stack down -e aws -y`,
 		proj, err := project.FromConfig(config)
 		cobra.CheckErr(err)
 
-		p, err := provider.NewProvider(proj, s, map[string]string{}, &types.ProviderOpts{Force: true})
+		p, err := provider.NewProvider(proj, s.Name, s.Provider, map[string]string{}, &types.ProviderOpts{Force: true})
 		cobra.CheckErr(err)
 
 		deploy := tasklet.Runner{
@@ -275,7 +271,7 @@ nitric stack list -s aws
 		proj, err := project.FromConfig(config)
 		cobra.CheckErr(err)
 
-		p, err := provider.NewProvider(proj, s, map[string]string{}, &types.ProviderOpts{})
+		p, err := provider.NewProvider(proj, s.Name, s.Provider, map[string]string{}, &types.ProviderOpts{})
 		cobra.CheckErr(err)
 
 		deps, err := p.List()

--- a/pkg/codeconfig/codeconfig.go
+++ b/pkg/codeconfig/codeconfig.go
@@ -606,7 +606,7 @@ func (c *codeConfig) ToProject() (*project.Project, error) {
 
 		fun, ok := s.Functions[f.name]
 		if !ok {
-			fun, err = project.FunctionFromHandler(handler, s.Dir)
+			fun, err = project.FunctionFromHandler(handler)
 			if err != nil {
 				errs.Push(fmt.Errorf("can not create function from %s %w", handler, err))
 				continue

--- a/pkg/output/format_test.go
+++ b/pkg/output/format_test.go
@@ -35,12 +35,11 @@ func Test_printStruct(t *testing.T) {
 	}{
 		{
 			name:   "json tags",
-			object: stack.Config{Name: "prod", Provider: "azure", Region: "somewhere"},
-			expect: `+----------+-----------+
-| NAME     | prod      |
-| PROVIDER | azure     |
-| REGION   | somewhere |
-+----------+-----------+
+			object: stack.Config{Name: "prod", Provider: "azure"},
+			expect: `+----------+-------+
+| NAME     | prod  |
+| PROVIDER | azure |
++----------+-------+
 `,
 		},
 	}
@@ -64,15 +63,15 @@ func Test_printList(t *testing.T) {
 		{
 			name: "json tags",
 			object: []stack.Config{
-				{Name: "a", Provider: "azure", Region: "somewhere"},
-				{Name: "b", Provider: "aws", Region: "xyz"},
+				{Name: "a", Provider: "azure"},
+				{Name: "b", Provider: "aws"},
 			},
-			expect: `+------+----------+-----------+
-| NAME | PROVIDER | REGION    |
-+------+----------+-----------+
-| b    | aws      | xyz       |
-| a    | azure    | somewhere |
-+------+----------+-----------+
+			expect: `+------+----------+
+| NAME | PROVIDER |
++------+----------+
+| b    | aws      |
+| a    | azure    |
++------+----------+
 `,
 		},
 	}
@@ -99,15 +98,15 @@ func Test_printMap(t *testing.T) {
 		{
 			name: "json tags",
 			object: map[string]stack.Config{
-				"t1": {Provider: "azure", Region: "somewhere"},
-				"t3": {Provider: "aws", Name: "foo"},
+				"t1": {Provider: "azure"},
+				"t3": {Name: "foo", Provider: "aws"},
 			},
-			wantOut: `+-----+------+----------+-----------+
-| KEY | NAME | PROVIDER | REGION    |
-+-----+------+----------+-----------+
-| t1  |      | azure    | somewhere |
-| t3  | foo  | aws      |           |
-+-----+------+----------+-----------+
+			wantOut: `+-----+------+----------+
+| KEY | NAME | PROVIDER |
++-----+------+----------+
+| t1  |      | azure    |
+| t3  | foo  | aws      |
++-----+------+----------+
 `,
 		},
 	}

--- a/pkg/project/options_test.go
+++ b/pkg/project/options_test.go
@@ -43,8 +43,10 @@ func TestFromConfig(t *testing.T) {
 				Name: "project",
 				Functions: map[string]Function{
 					"project": {
-						Handler:     "types.go",
-						ComputeUnit: ComputeUnit{Name: "project"},
+						Handler: "types.go",
+						ComputeUnit: ComputeUnit{
+							Name: "project",
+						},
 					},
 				},
 			},
@@ -61,8 +63,10 @@ func TestFromConfig(t *testing.T) {
 				Name: "pkg",
 				Functions: map[string]Function{
 					"stack": {
-						Handler:     "stack/options.go",
-						ComputeUnit: ComputeUnit{Name: "stack"},
+						Handler: "stack/options.go",
+						ComputeUnit: ComputeUnit{
+							Name: "stack",
+						},
 					},
 				},
 			},

--- a/pkg/project/types.go
+++ b/pkg/project/types.go
@@ -39,14 +39,17 @@ type ComputeUnit struct {
 	// Triggers used to invoke this compute unit, e.g. Topic Subscriptions
 	Triggers Triggers `yaml:"triggers,omitempty"`
 
-	// The memory of the compute instance in MB
+	// The memory of the compute instance in MB: default 128
 	Memory int `yaml:"memory,omitempty"`
 
-	// The minimum number of instances to keep alive
+	// The minimum number of instances to keep alive: default 0
 	MinScale int `yaml:"minScale,omitempty"`
 
-	// The maximum number of instances to scale to
+	// The maximum number of instances to scale to: default 10
 	MaxScale int `yaml:"maxScale,omitempty"`
+
+	// The max running time of the function: default 15
+	Timeout int `yaml:"timeout,omitempty"`
 }
 
 type Function struct {

--- a/pkg/provider/generator.go
+++ b/pkg/provider/generator.go
@@ -22,15 +22,14 @@ import (
 	"github.com/nitrictech/cli/pkg/project"
 	"github.com/nitrictech/cli/pkg/provider/pulumi"
 	"github.com/nitrictech/cli/pkg/provider/types"
-	"github.com/nitrictech/cli/pkg/stack"
 	"github.com/nitrictech/cli/pkg/utils"
 )
 
-func NewProvider(p *project.Project, s *stack.Config, envMap map[string]string, opts *types.ProviderOpts) (types.Provider, error) {
-	switch s.Provider {
-	case stack.Aws, stack.Azure, stack.Digitalocean, stack.Gcp:
-		return pulumi.New(p, s, envMap, opts)
+func NewProvider(p *project.Project, name, provider string, envMap map[string]string, opts *types.ProviderOpts) (types.Provider, error) {
+	switch provider {
+	case types.Aws, types.Azure, types.Digitalocean, types.Gcp:
+		return pulumi.New(p, name, provider, envMap, opts)
 	default:
-		return nil, utils.NewNotSupportedErr(fmt.Sprintf("provider %s is not supported", s.Provider))
+		return nil, utils.NewNotSupportedErr(fmt.Sprintf("provider %s is not supported", provider))
 	}
 }

--- a/pkg/provider/pulumi/aws/aws_test.go
+++ b/pkg/provider/pulumi/aws/aws_test.go
@@ -17,10 +17,12 @@
 package aws
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
 
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/hashicorp/go-version"
 	"github.com/pulumi/pulumi-aws/sdk/v4/go/aws/dynamodb"
 	"github.com/pulumi/pulumi-aws/sdk/v4/go/aws/s3"
@@ -33,7 +35,7 @@ import (
 
 	"github.com/nitrictech/cli/pkg/project"
 	"github.com/nitrictech/cli/pkg/provider/pulumi/common"
-	"github.com/nitrictech/cli/pkg/stack"
+	"github.com/nitrictech/cli/pkg/provider/types"
 	v1 "github.com/nitrictech/nitric/pkg/api/nitric/v1"
 )
 
@@ -110,9 +112,15 @@ func TestAWS(t *testing.T) {
 
 	a := &awsProvider{
 		proj: s,
-		sc: &stack.Config{
-			Provider: stack.Aws,
+		sc: &awsStackConfig{
+			Provider: types.Aws,
 			Region:   "mock",
+			Config: map[string]awsFunctionConfig{
+				"functions/create/main.go": {
+					Memory:  to.IntPtr(1024),
+					Timeout: to.IntPtr(23),
+				},
+			},
 		},
 		topics:      map[string]*sns.Topic{},
 		buckets:     map[string]*s3.Bucket{},
@@ -130,7 +138,10 @@ func TestAWS(t *testing.T) {
 	}
 
 	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
-		err := a.Deploy(ctx)
+		err := a.Configure(context.TODO(), nil)
+		assert.NoError(t, err)
+
+		err = a.Deploy(ctx)
 		assert.NoError(t, err)
 
 		var wg sync.WaitGroup
@@ -229,13 +240,15 @@ func TestAWS(t *testing.T) {
 		})
 
 		wg.Add(1)
-		pulumi.All(a.funcs["runner"].Function.ImageUri, a.funcs["runner"].Function.Role, a.funcs["runner"].Role.Arn).ApplyT(func(all []interface{}) error {
+		pulumi.All(a.funcs["runner"].Function.ImageUri, a.funcs["runner"].Function.Role, a.funcs["runner"].Role.Arn, a.funcs["runner"].Function.MemorySize).ApplyT(func(all []interface{}) error {
 			imageUri := all[0].(*string)
 			fRole := all[1].(string)
 			roleArn := all[2].(string)
+			memSize := all[3].(*int)
 
 			assert.Equal(t, "docker.io/nitrictech/runner:latest", *imageUri, "wrong imageUri %s!=%s", "", *imageUri)
 			assert.Equal(t, roleArn, fRole, "wrong role %s!=%s", roleArn, fRole)
+			assert.Equal(t, *memSize, 1024)
 			wg.Done()
 
 			return nil
@@ -266,23 +279,23 @@ func TestAWS(t *testing.T) {
 func TestValidate(t *testing.T) {
 	tests := []struct {
 		name    string
-		t       *stack.Config
+		t       *awsStackConfig
 		wantErr bool
 	}{
 		{
 			name: "valid",
-			t:    &stack.Config{Provider: stack.Aws, Region: "us-west-1"},
+			t:    &awsStackConfig{Provider: types.Aws, Region: "us-west-1"},
 		},
 		{
 			name:    "invalid",
-			t:       &stack.Config{Provider: stack.Aws, Region: "pole-north-right-next-to-santa"},
+			t:       &awsStackConfig{Provider: types.Aws, Region: "pole-north-right-next-to-santa"},
 			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			a := New(nil, tt.t, map[string]string{})
+			a := &awsProvider{sc: tt.t}
 
 			if err := a.Validate(); (err != nil) != tt.wantErr {
 				t.Errorf("awsProvider.Validate() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/provider/pulumi/aws/lambda.go
+++ b/pkg/provider/pulumi/aws/lambda.go
@@ -131,12 +131,10 @@ func newLambda(ctx *pulumi.Context, name string, args *LambdaArgs, opts ...pulum
 		envVars[k] = pulumi.String(v)
 	}
 
-	memory := common.IntValueOrDefault(args.Compute.Unit().Memory, 128)
-
 	res.Function, err = awslambda.NewFunction(ctx, name, &awslambda.FunctionArgs{
 		ImageUri:    args.DockerImage.ImageName,
-		MemorySize:  pulumi.IntPtr(memory),
-		Timeout:     pulumi.IntPtr(15),
+		MemorySize:  pulumi.IntPtr(args.Compute.Unit().Memory),
+		Timeout:     pulumi.IntPtr(args.Compute.Unit().Timeout),
 		PackageType: pulumi.String("Image"),
 		Role:        res.Role.Arn,
 		Tags:        common.Tags(ctx, name),

--- a/pkg/provider/pulumi/azure/azure.go
+++ b/pkg/provider/pulumi/azure/azure.go
@@ -21,10 +21,10 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/golangci/golangci-lint/pkg/sliceutil"
 	multierror "github.com/missionMeteora/toolkit/errors"
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi-azure-native/sdk/go/azure/authorization"
@@ -34,20 +34,35 @@ import (
 	"github.com/pulumi/pulumi-azure-native/sdk/go/azure/resources"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"golang.org/x/exp/slices"
+	"gopkg.in/yaml.v2"
 
 	"github.com/nitrictech/cli/pkg/project"
 	"github.com/nitrictech/cli/pkg/provider/pulumi/common"
-	"github.com/nitrictech/cli/pkg/stack"
+	"github.com/nitrictech/cli/pkg/provider/types"
 	"github.com/nitrictech/cli/pkg/utils"
 )
 
+type azureFunctionConfig struct {
+	Memory  *int `yaml:"memory,omitempty"`
+	Timeout *int `yaml:"timeout,omitempty"`
+}
+
+type azureStackConfig struct {
+	Name     string `yaml:"name,omitempty"`
+	Provider string `yaml:"provider,omitempty"`
+	Region   string `yaml:"region,omitempty"`
+
+	AdminEmail string                         `yaml:"adminemail,omitempty"`
+	Org        string                         `yaml:"org,omitempty"`
+	Config     map[string]azureFunctionConfig `yaml:"config,omitempty"`
+}
+
 type azureProvider struct {
-	proj       *project.Project
-	sc         *stack.Config
-	envMap     map[string]string
-	tmpDir     string
-	org        string
-	adminEmail string
+	proj   *project.Project
+	sc     *azureStackConfig
+	envMap map[string]string
+	tmpDir string
 }
 
 var (
@@ -59,12 +74,24 @@ var (
 	azureNativePluginVersion string
 )
 
-func New(s *project.Project, t *stack.Config, envMap map[string]string) common.PulumiProvider {
-	return &azureProvider{
-		proj:   s,
-		sc:     t,
-		envMap: envMap,
+func New(p *project.Project, name string, envMap map[string]string) (common.PulumiProvider, error) {
+	b, err := os.ReadFile(filepath.Join(p.Dir, name+".yaml"))
+	if err != nil {
+		return nil, err
 	}
+
+	asc := &azureStackConfig{Name: name, Provider: types.Azure}
+
+	err = yaml.Unmarshal(b, asc)
+	if err != nil {
+		return nil, err
+	}
+
+	return &azureProvider{
+		proj:   p,
+		sc:     asc,
+		envMap: envMap,
+	}, nil
 }
 
 func (a *azureProvider) Plugins() []common.Plugin {
@@ -84,7 +111,7 @@ func (a *azureProvider) Plugins() []common.Plugin {
 	}
 }
 
-func (a *azureProvider) Ask() (*stack.Config, error) {
+func (a *azureProvider) AskAndSave() error {
 	answers := struct {
 		Region     string
 		Org        string
@@ -112,22 +139,21 @@ func (a *azureProvider) Ask() (*stack.Config, error) {
 		},
 	}
 
-	sc := &stack.Config{
-		Name:     a.sc.Name,
-		Provider: a.sc.Provider,
-		Extra:    map[string]interface{}{},
-	}
-
 	err := survey.Ask(qs, &answers)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	sc.Region = answers.Region
-	sc.Extra["adminemail"] = answers.AdminEmail
-	sc.Extra["org"] = answers.Org
+	a.sc.Region = answers.Region
+	a.sc.AdminEmail = answers.AdminEmail
+	a.sc.Org = answers.Org
 
-	return sc, nil
+	b, err := yaml.Marshal(a.sc)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(a.proj.Dir, fmt.Sprintf("nitric-%s.yaml", a.sc.Name)), b, 0o644)
 }
 
 func (a *azureProvider) SupportedRegions() []string {
@@ -150,20 +176,26 @@ func (a *azureProvider) Validate() error {
 
 	if a.sc.Region == "" {
 		errList.Push(fmt.Errorf("target %s requires \"region\"", a.sc.Provider))
-	} else if !sliceutil.Contains(a.SupportedRegions(), a.sc.Region) {
+	} else if !slices.Contains(a.SupportedRegions(), a.sc.Region) {
 		errList.Push(utils.NewNotSupportedErr(fmt.Sprintf("region %s not supported on provider %s", a.sc.Region, a.sc.Provider)))
 	}
 
-	if _, ok := a.sc.Extra["org"]; !ok {
+	if a.sc.Org == "" {
 		errList.Push(fmt.Errorf("target %s requires \"org\"", a.sc.Provider))
-	} else {
-		a.org = a.sc.Extra["org"].(string)
 	}
 
-	if _, ok := a.sc.Extra["adminemail"]; !ok {
+	if a.sc.AdminEmail == "" {
 		errList.Push(fmt.Errorf("target %s requires \"adminemail\"", a.sc.Provider))
-	} else {
-		a.adminEmail = a.sc.Extra["adminemail"].(string)
+	}
+
+	for fn, fc := range a.sc.Config {
+		if fc.Memory != nil && *fc.Memory < 128 {
+			errList.Push(fmt.Errorf("function config %s requires \"memory\" to be greater than 128 Mi", fn))
+		}
+
+		if fc.Timeout != nil && *fc.Timeout < 15 {
+			errList.Push(fmt.Errorf("function config %s requires \"timeout\" to be greater than 15 seconds", fn))
+		}
 	}
 
 	return errList.Err()
@@ -190,6 +222,36 @@ func (a *azureProvider) Configure(ctx context.Context, autoStack *auto.Stack) er
 	}
 
 	a.sc.Region = region.Value
+
+	dc, dok := a.sc.Config["default"]
+
+	for fn, f := range a.proj.Functions {
+		f.ComputeUnit.Memory = 512
+		f.ComputeUnit.Timeout = 15
+
+		if dok {
+			if dc.Memory != nil {
+				f.ComputeUnit.Memory = *dc.Memory
+			}
+
+			if dc.Timeout != nil {
+				f.ComputeUnit.Timeout = *dc.Timeout
+			}
+		}
+
+		fc, ok := a.sc.Config[f.Handler]
+		if ok {
+			if fc.Memory != nil {
+				f.ComputeUnit.Memory = *fc.Memory
+			}
+
+			if fc.Timeout != nil {
+				f.ComputeUnit.Timeout = *fc.Timeout
+			}
+		}
+
+		a.proj.Functions[fn] = f
+	}
 
 	return nil
 }
@@ -318,8 +380,8 @@ func (a *azureProvider) Deploy(ctx *pulumi.Context) error {
 	for k, v := range a.proj.ApiDocs {
 		_, err = newAzureApiManagement(ctx, k, &AzureApiManagementArgs{
 			ResourceGroupName:   rg.Name,
-			OrgName:             pulumi.String(a.org),
-			AdminEmail:          pulumi.String(a.adminEmail),
+			OrgName:             pulumi.String(a.sc.Org),
+			AdminEmail:          pulumi.String(a.sc.AdminEmail),
 			OpenAPISpec:         v,
 			Apps:                apps.Apps,
 			SecurityDefinitions: a.proj.SecurityDefinitions[k],

--- a/pkg/provider/pulumi/common/types.go
+++ b/pkg/provider/pulumi/common/types.go
@@ -21,8 +21,6 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-
-	"github.com/nitrictech/cli/pkg/stack"
 )
 
 type Plugin struct {
@@ -40,7 +38,7 @@ type PulumiProvider interface {
 	Configure(context.Context, *auto.Stack) error
 	Deploy(*pulumi.Context) error
 	CleanUp()
-	Ask() (*stack.Config, error)
+	AskAndSave() error
 	SupportedRegions() []string
 }
 

--- a/pkg/provider/pulumi/gcp/cloudrunner.go
+++ b/pkg/provider/pulumi/gcp/cloudrunner.go
@@ -79,7 +79,6 @@ func (g *gcpProvider) newCloudRunner(ctx *pulumi.Context, name string, args *Clo
 	}
 
 	// Deploy the func
-	memory := common.IntValueOrDefault(args.Compute.Unit().Memory, 512)
 	maxScale := common.IntValueOrDefault(args.Compute.Unit().MaxScale, 10)
 	minScale := common.IntValueOrDefault(args.Compute.Unit().MinScale, 0)
 
@@ -106,7 +105,7 @@ func (g *gcpProvider) newCloudRunner(ctx *pulumi.Context, name string, args *Clo
 							},
 						},
 						Resources: cloudrun.ServiceTemplateSpecContainerResourcesArgs{
-							Limits: pulumi.StringMap{"memory": pulumi.Sprintf("%dMi", memory)},
+							Limits: pulumi.StringMap{"memory": pulumi.Sprintf("%dMi", args.Compute.Unit().Memory)},
 						},
 					},
 				},

--- a/pkg/provider/pulumi/gcp/gcp.go
+++ b/pkg/provider/pulumi/gcp/gcp.go
@@ -25,11 +25,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/getkin/kin-openapi/openapi2conv"
-	"github.com/golangci/golangci-lint/pkg/sliceutil"
 	multierror "github.com/missionMeteora/toolkit/errors"
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/cloudscheduler"
@@ -42,18 +42,33 @@ import (
 	"github.com/pulumi/pulumi-random/sdk/v4/go/random"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"golang.org/x/exp/slices"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
+	"gopkg.in/yaml.v2"
 
 	"github.com/nitrictech/cli/pkg/project"
 	"github.com/nitrictech/cli/pkg/provider/pulumi/common"
-	"github.com/nitrictech/cli/pkg/stack"
+	"github.com/nitrictech/cli/pkg/provider/types"
 	"github.com/nitrictech/cli/pkg/utils"
 	v1 "github.com/nitrictech/nitric/pkg/api/nitric/v1"
 )
 
+type gcpFunctionConfig struct {
+	Memory  *int `yaml:"memory,omitempty"`
+	Timeout *int `yaml:"timeout,omitempty"`
+}
+
+type gcpStackConfig struct {
+	Name     string                       `yaml:"name,omitempty"`
+	Provider string                       `yaml:"provider,omitempty"`
+	Region   string                       `yaml:"region,omitempty"`
+	Project  string                       `yaml:"project,omitempty"`
+	Config   map[string]gcpFunctionConfig `yaml:"config,omitempty"`
+}
+
 type gcpProvider struct {
-	sc         *stack.Config
+	sc         *gcpStackConfig
 	proj       *project.Project
 	envMap     map[string]string
 	tmpDir     string
@@ -78,10 +93,22 @@ var gcpPluginVersion string
 //go:embed pulumi-random-version.txt
 var randomPluginVersion string
 
-func New(s *project.Project, t *stack.Config, envMap map[string]string) common.PulumiProvider {
+func New(p *project.Project, name string, envMap map[string]string) (common.PulumiProvider, error) {
+	b, err := os.ReadFile(filepath.Join(p.Dir, name+".yaml"))
+	if err != nil {
+		return nil, err
+	}
+
+	gsc := &gcpStackConfig{Name: name, Provider: types.Gcp}
+
+	err = yaml.Unmarshal(b, gsc)
+	if err != nil {
+		return nil, err
+	}
+
 	return &gcpProvider{
-		proj:               s,
-		sc:                 t,
+		proj:               p,
+		sc:                 gsc,
 		envMap:             envMap,
 		buckets:            map[string]*storage.Bucket{},
 		topics:             map[string]*pubsub.Topic{},
@@ -90,7 +117,7 @@ func New(s *project.Project, t *stack.Config, envMap map[string]string) common.P
 		images:             map[string]*common.Image{},
 		cloudRunners:       map[string]*CloudRunner{},
 		secrets:            map[string]*secretmanager.Secret{},
-	}
+	}, nil
 }
 
 func (g *gcpProvider) Plugins() []common.Plugin {
@@ -137,7 +164,7 @@ func (g *gcpProvider) SupportedRegions() []string {
 	}
 }
 
-func (a *gcpProvider) Ask() (*stack.Config, error) {
+func (g *gcpProvider) AskAndSave() error {
 	answers := struct {
 		Region  string
 		Project string
@@ -148,7 +175,7 @@ func (a *gcpProvider) Ask() (*stack.Config, error) {
 			Name: "region",
 			Prompt: &survey.Select{
 				Message: "select the region",
-				Options: a.SupportedRegions(),
+				Options: g.SupportedRegions(),
 			},
 		},
 		{
@@ -159,21 +186,20 @@ func (a *gcpProvider) Ask() (*stack.Config, error) {
 		},
 	}
 
-	sc := &stack.Config{
-		Name:     a.sc.Name,
-		Provider: a.sc.Provider,
-		Extra:    map[string]interface{}{},
-	}
-
 	err := survey.Ask(qs, &answers)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	sc.Region = answers.Region
-	sc.Extra["project"] = answers.Project
+	g.sc.Region = answers.Region
+	g.sc.Project = answers.Project
 
-	return sc, nil
+	b, err := yaml.Marshal(g.sc)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(g.proj.Dir, fmt.Sprintf("nitric-%s.yaml", g.sc.Name)), b, 0o644)
 }
 
 func (g *gcpProvider) Validate() error {
@@ -181,20 +207,60 @@ func (g *gcpProvider) Validate() error {
 
 	if g.sc.Region == "" {
 		errList.Push(fmt.Errorf("target %s requires \"region\"", g.sc.Provider))
-	} else if !sliceutil.Contains(g.SupportedRegions(), g.sc.Region) {
+	} else if !slices.Contains(g.SupportedRegions(), g.sc.Region) {
 		errList.Push(utils.NewNotSupportedErr(fmt.Sprintf("region %s not supported on provider %s", g.sc.Region, g.sc.Provider)))
 	}
 
-	if proj, ok := g.sc.Extra["project"]; !ok || proj == nil {
+	if g.sc.Project == "" {
 		errList.Push(fmt.Errorf("target %s requires GCP \"project\"", g.sc.Provider))
 	} else {
-		g.gcpProject = proj.(string)
+		g.gcpProject = g.sc.Project
+	}
+
+	for fn, fc := range g.sc.Config {
+		if fc.Memory != nil && *fc.Memory < 128 {
+			errList.Push(fmt.Errorf("function config %s requires \"memory\" to be greater than 128 Mi", fn))
+		}
+
+		if fc.Timeout != nil && *fc.Timeout < 15 {
+			errList.Push(fmt.Errorf("function config %s requires \"timeout\" to be greater than 15 seconds", fn))
+		}
 	}
 
 	return errList.Err()
 }
 
 func (g *gcpProvider) Configure(ctx context.Context, autoStack *auto.Stack) error {
+	dc, dok := g.sc.Config["default"]
+
+	for fn, f := range g.proj.Functions {
+		f.ComputeUnit.Memory = 512
+		f.ComputeUnit.Timeout = 15
+
+		if dok {
+			if dc.Memory != nil {
+				f.ComputeUnit.Memory = *dc.Memory
+			}
+
+			if dc.Timeout != nil {
+				f.ComputeUnit.Timeout = *dc.Timeout
+			}
+		}
+
+		fc, ok := g.sc.Config[f.Handler]
+		if ok {
+			if fc.Memory != nil {
+				f.ComputeUnit.Memory = *fc.Memory
+			}
+
+			if fc.Timeout != nil {
+				f.ComputeUnit.Timeout = *fc.Timeout
+			}
+		}
+
+		g.proj.Functions[fn] = f
+	}
+
 	err := autoStack.SetConfig(ctx, "gcp:region", auto.ConfigValue{Value: g.sc.Region})
 	if err != nil {
 		return err

--- a/pkg/provider/types/interface.go
+++ b/pkg/provider/types/interface.go
@@ -18,8 +18,16 @@ package types
 
 import (
 	"github.com/nitrictech/cli/pkg/output"
-	"github.com/nitrictech/cli/pkg/stack"
 )
+
+const (
+	Aws          = "aws"
+	Azure        = "azure"
+	Gcp          = "gcp"
+	Digitalocean = "digitalocean"
+)
+
+var Providers = []string{Aws, Azure, Gcp, Digitalocean}
 
 type ResourceState struct {
 	OpType   string
@@ -44,7 +52,7 @@ type Provider interface {
 	Up(log output.Progress) (*Deployment, error)
 	Down(log output.Progress) (*Summary, error)
 	List() (interface{}, error)
-	Ask() (*stack.Config, error)
+	AskAndSave() error
 	SupportedRegions() []string
 	// Status()
 }

--- a/pkg/stack/data/nitric-x.yaml
+++ b/pkg/stack/data/nitric-x.yaml
@@ -1,5 +1,2 @@
 name: zed
 provider: Azure
-region: eastus2
-adminemail: admin@example.com
-org: example.com

--- a/pkg/stack/options.go
+++ b/pkg/stack/options.go
@@ -35,15 +35,6 @@ func ConfigFromOptions() (*Config, error) {
 	return configFromFile("nitric-" + stack + ".yaml")
 }
 
-func (p *Config) ToFile(file string) error {
-	b, err := yaml.Marshal(p)
-	if err != nil {
-		return err
-	}
-
-	return os.WriteFile(file, b, 0o644)
-}
-
 func configFromFile(file string) (*Config, error) {
 	s := &Config{}
 

--- a/pkg/stack/options_test.go
+++ b/pkg/stack/options_test.go
@@ -25,11 +25,6 @@ func Test_configFromFile(t *testing.T) {
 	want := &Config{
 		Name:     "zed",
 		Provider: "Azure",
-		Region:   "eastus2",
-		Extra: map[string]interface{}{
-			"adminemail": "admin@example.com",
-			"org":        "example.com",
-		},
 	}
 
 	got, err := configFromFile("data/nitric-x.yaml")

--- a/pkg/stack/types.go
+++ b/pkg/stack/types.go
@@ -16,18 +16,7 @@
 
 package stack
 
-const (
-	Aws          = "aws"
-	Azure        = "azure"
-	Gcp          = "gcp"
-	Digitalocean = "digitalocean"
-)
-
-var Providers = []string{Aws, Azure, Gcp, Digitalocean}
-
 type Config struct {
-	Name     string                 `yaml:"name,omitempty"`
-	Provider string                 `yaml:"provider,omitempty"`
-	Region   string                 `yaml:"region,omitempty"`
-	Extra    map[string]interface{} `yaml:",inline,omitempty"`
+	Name     string `yaml:"name,omitempty"`
+	Provider string `yaml:"provider,omitempty"`
 }


### PR DESCRIPTION
I used a stack config of :
```yaml
name: staging
provider: gcp
region: australia-southeast1
project: thing
config:
  default:
    memory: 512
  functions/api/main.go:
    timeout: 30
```