### PR TITLE
Release

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,8 @@ issues:
 linters-settings:
   goimports:
     local-prefixes: github.com/nitrictech
+  errorlint:
+    asserts: false
   govet:
     check-shadowing: false
   goheader:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/nitrictech/cli/Tests/develop?label=tests)
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/nitrictech/cli)
 ![GitHub all releases](https://img.shields.io/github/downloads/nitrictech/cli/total)
+  <a href="https://discord.gg/Webemece5C"><img alt="Discord" src="https://img.shields.io/discord/955259353043173427?label=discord"></a>
 
 ## Overview
 
@@ -60,6 +61,8 @@ Documentation for all available commands:
 ## Get in touch
 
 - Ask questions in [GitHub discussions](https://github.com/nitrictech/nitric/discussions)
+
+- Join us on [Discord](https://discord.gg/Webemece5C)
 
 - Find us on [Twitter](https://twitter.com/nitric_io)
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Common commands in the CLI that you’ll be using:
 - nitric down : Undeploy a previously deployed stack, deleting resources
 - nitric run : Run your project locally for development and testing
 - nitric stack new : Create a new Nitric stack
+- nitric start : Run nitric services locally for development and testing
 - nitric up : Create or update a deployed stack
 
 ## Help with Commands
@@ -55,6 +56,7 @@ Documentation for all available commands:
 - nitric stack new : Create a new Nitric stack
 - nitric stack update [-s stack] : Create or update a deployed stack
   (alias: nitric up)
+- nitric start : Run nitric services locally for development and testing
 - nitric version : Print the version number of this CLI
 
 ## Get in touch

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/nitrictech/cli/pkg/cmd/run"
 	cmdstack "github.com/nitrictech/cli/pkg/cmd/stack"
+	"github.com/nitrictech/cli/pkg/cmd/start"
 	"github.com/nitrictech/cli/pkg/ghissue"
 	"github.com/nitrictech/cli/pkg/output"
 	"github.com/nitrictech/cli/pkg/utils"
@@ -102,6 +103,7 @@ func init() {
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(feedbackCmd)
 	rootCmd.AddCommand(infoCmd)
+	rootCmd.AddCommand(start.RootCommand())
 	addAlias("stack update", "up", true)
 	addAlias("stack down", "down", true)
 	addAlias("stack list", "list", false)

--- a/pkg/cmd/stack/root.go
+++ b/pkg/cmd/stack/root.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path"
-	"runtime"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/joho/godotenv"
@@ -138,11 +137,6 @@ var stackUpdateCmd = &cobra.Command{
 	Long:    `Create or update a deployed stack`,
 	Example: `nitric stack update -s aws`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// FIXME: Remove this error once multi-architecture support is complete
-		if runtime.GOARCH != "amd64" {
-			cobra.CheckErr(fmt.Errorf("only x86_64 CPU architectures are supported for the `nitric up` command currently.\nSee https://github.com/nitrictech/nitric/issues/283 for updated status on multi-architecture support"))
-		}
-
 		s, err := stack.ConfigFromOptions()
 		cobra.CheckErr(err)
 

--- a/pkg/cmd/start/root.go
+++ b/pkg/cmd/start/root.go
@@ -38,7 +38,7 @@ import (
 
 var envFile string
 
-var servicesCmd = &cobra.Command{
+var startCmd = &cobra.Command{
 	Use:         "start",
 	Short:       "Run nitric services locally for development and testing",
 	Long:        `Run nitric services locally for development and testing`,
@@ -140,6 +140,5 @@ var servicesCmd = &cobra.Command{
 }
 
 func RootCommand() *cobra.Command {
-	servicesCmd.Flags().StringVarP(&envFile, "env-file", "e", "", "--env-file config/.my-env")
-	return servicesCmd
+	return startCmd
 }

--- a/pkg/cmd/start/root.go
+++ b/pkg/cmd/start/root.go
@@ -36,8 +36,6 @@ import (
 	"github.com/nitrictech/cli/pkg/tasklet"
 )
 
-var envFile string
-
 var startCmd = &cobra.Command{
 	Use:         "start",
 	Short:       "Run nitric services locally for development and testing",

--- a/pkg/cmd/start/root.go
+++ b/pkg/cmd/start/root.go
@@ -1,0 +1,145 @@
+// Copyright Nitric Pty Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package start
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+
+	"github.com/nitrictech/cli/pkg/output"
+	"github.com/nitrictech/cli/pkg/project"
+	"github.com/nitrictech/cli/pkg/run"
+	"github.com/nitrictech/cli/pkg/tasklet"
+)
+
+var envFile string
+
+var servicesCmd = &cobra.Command{
+	Use:         "start",
+	Short:       "Run nitric services locally for development and testing",
+	Long:        `Run nitric services locally for development and testing`,
+	Example:     `nitric start`,
+	Annotations: map[string]string{"commonCommand": "yes"},
+	Run: func(cmd *cobra.Command, args []string) {
+		term := make(chan os.Signal, 1)
+		signal.Notify(term, os.Interrupt, syscall.SIGTERM)
+		signal.Notify(term, os.Interrupt, syscall.SIGINT)
+
+		// Divert default log output to pterm debug
+		log.SetOutput(output.NewPtermWriter(pterm.Debug))
+
+		ls := run.NewLocalServices(&project.Project{
+			Name: "local",
+		})
+		if ls.Running() {
+			pterm.Error.Println("Only one instance of Nitric can be run locally at a time, please check that you have ended all other instances and try again")
+			os.Exit(2)
+		}
+
+		memerr := make(chan error)
+		pool := run.NewRunProcessPool()
+
+		startLocalServices := tasklet.Runner{
+			StartMsg: "Starting Local Services",
+			Runner: func(progress output.Progress) error {
+				go func(errch chan error) {
+					errch <- ls.Start(pool)
+				}(memerr)
+
+				for {
+					select {
+					case err := <-memerr:
+						// catch any early errors from Start()
+						if err != nil {
+							return err
+						}
+					default:
+					}
+					if ls.Running() {
+						break
+					}
+					progress.Busyf("Waiting for Local Services to be ready")
+					time.Sleep(time.Second)
+				}
+				return nil
+			},
+			StopMsg: "Started Local Services!",
+		}
+		tasklet.MustRun(startLocalServices, tasklet.Opts{
+			Signal: term,
+		})
+
+		pterm.DefaultBasicText.Println("Local running, use ctrl-C to stop")
+
+		stackState := run.NewStackState()
+
+		area, _ := pterm.DefaultArea.Start()
+		lck := sync.Mutex{}
+		// React to worker pool state and update services table
+		pool.Listen(func(we run.WorkerEvent) {
+			lck.Lock()
+			defer lck.Unlock()
+			// area.Clear()
+
+			stackState.UpdateFromWorkerEvent(we)
+
+			tables := []string{}
+			table, rows := stackState.ApiTable(9001)
+			if rows > 0 {
+				tables = append(tables, table)
+			}
+
+			table, rows = stackState.TopicTable(9001)
+			if rows > 0 {
+				tables = append(tables, table)
+			}
+
+			table, rows = stackState.SchedulesTable(9001)
+			if rows > 0 {
+				tables = append(tables, table)
+			}
+			area.Update(strings.Join(tables, "\n\n"))
+		})
+
+		select {
+		case membraneError := <-memerr:
+			fmt.Println(errors.WithMessage(membraneError, "membrane error, exiting"))
+		case <-term:
+			fmt.Println("Shutting down services - exiting")
+		}
+
+		_ = area.Stop()
+		// Stop the membrane
+		cobra.CheckErr(ls.Stop())
+	},
+	Args: cobra.ExactArgs(0),
+}
+
+func RootCommand() *cobra.Command {
+	servicesCmd.Flags().StringVarP(&envFile, "env-file", "e", "", "--env-file config/.my-env")
+	return servicesCmd
+}

--- a/pkg/provider/pulumi/aws/aws.go
+++ b/pkg/provider/pulumi/aws/aws.go
@@ -383,7 +383,7 @@ func (a *awsProvider) Deploy(ctx *pulumi.Context) error {
 				Username:      pulumi.String(authToken.UserName),
 				Password:      pulumi.String(authToken.Password),
 				TempDir:       a.tmpDir,
-			}, pulumi.DependsOn([]pulumi.Resource{ repo }))
+			}, pulumi.DependsOn([]pulumi.Resource{repo}))
 			if err != nil {
 				return errors.WithMessage(err, "function image tag "+c.Unit().Name)
 			}

--- a/pkg/provider/pulumi/aws/aws.go
+++ b/pkg/provider/pulumi/aws/aws.go
@@ -383,7 +383,7 @@ func (a *awsProvider) Deploy(ctx *pulumi.Context) error {
 				Username:      pulumi.String(authToken.UserName),
 				Password:      pulumi.String(authToken.Password),
 				TempDir:       a.tmpDir,
-			})
+			}, pulumi.DependsOn([]pulumi.Resource{ repo }))
 			if err != nil {
 				return errors.WithMessage(err, "function image tag "+c.Unit().Name)
 			}

--- a/pkg/provider/pulumi/common/image.go
+++ b/pkg/provider/pulumi/common/image.go
@@ -72,7 +72,12 @@ func NewImage(ctx *pulumi.Context, name string, args *ImageArgs, opts ...pulumi.
 		},
 	}
 
-	res.DockerImage, err = dockerbuildkit.NewImage(ctx, name+"-image", imageArgs, pulumi.Parent(res))
+	resOpts := []pulumi.ResourceOption{ pulumi.Parent(res) }
+	for _, o := range opts {
+		resOpts = append(resOpts, o)
+	}
+
+	res.DockerImage, err = dockerbuildkit.NewImage(ctx, name+"-image", imageArgs, resOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/pulumi/common/image.go
+++ b/pkg/provider/pulumi/common/image.go
@@ -72,12 +72,7 @@ func NewImage(ctx *pulumi.Context, name string, args *ImageArgs, opts ...pulumi.
 		},
 	}
 
-	resOpts := []pulumi.ResourceOption{ pulumi.Parent(res) }
-	for _, o := range opts {
-		resOpts = append(resOpts, o)
-	}
-
-	res.DockerImage, err = dockerbuildkit.NewImage(ctx, name+"-image", imageArgs, resOpts...)
+	res.DockerImage, err = dockerbuildkit.NewImage(ctx, name+"-image", imageArgs, append(opts, pulumi.Parent(res))...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -112,7 +112,7 @@ func (l *localServices) Start(pool worker.WorkerPool) error {
 	os.Setenv(minio.MINIO_ACCESS_KEY_ENV, "minioadmin")
 	os.Setenv(minio.MINIO_SECRET_KEY_ENV, "minioadmin")
 
-	sp, err := minio.New()
+	sp, err := NewStorage()
 	if err != nil {
 		return err
 	}

--- a/pkg/run/storage.go
+++ b/pkg/run/storage.go
@@ -1,0 +1,173 @@
+// Copyright Nitric Pty Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package run
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/nitrictech/nitric/pkg/plugins/storage"
+	s3_service "github.com/nitrictech/nitric/pkg/plugins/storage/s3"
+	"github.com/nitrictech/nitric/pkg/utils"
+)
+
+type RunStorageService struct {
+	storage.StorageService
+	client *s3.S3
+}
+
+const (
+	MINIO_ENDPOINT_ENV   = "MINIO_ENDPOINT"
+	MINIO_ACCESS_KEY_ENV = "MINIO_ACCESS_KEY"
+	MINIO_SECRET_KEY_ENV = "MINIO_SECRET_KEY"
+)
+
+type minioConfig struct {
+	endpoint  string
+	accessKey string
+	secretKey string
+}
+
+func (r *RunStorageService) ensureBucketExists(bucket string) error {
+	_, err := r.client.HeadBucket(&s3.HeadBucketInput{
+		Bucket: aws.String(bucket),
+	})
+
+	if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == s3.ErrCodeNoSuchBucket {
+		_, err = r.client.CreateBucket(&s3.CreateBucketInput{
+			Bucket:           aws.String(bucket),
+			GrantFullControl: aws.String("*"),
+		})
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *RunStorageService) Read(bucket string, key string) ([]byte, error) {
+	err := r.ensureBucketExists(bucket)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.StorageService.Read(bucket, key)
+}
+
+func (r *RunStorageService) Write(bucket string, key string, object []byte) error {
+	err := r.ensureBucketExists(bucket)
+	if err != nil {
+		return err
+	}
+
+	return r.StorageService.Write(bucket, key, object)
+}
+
+func (r *RunStorageService) Delete(bucket string, key string) error {
+	err := r.ensureBucketExists(bucket)
+	if err != nil {
+		return err
+	}
+
+	return r.StorageService.Delete(bucket, key)
+}
+
+func (r *RunStorageService) ListFiles(bucket string) ([]*storage.FileInfo, error) {
+	err := r.ensureBucketExists(bucket)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.StorageService.ListFiles(bucket)
+}
+
+func (r *RunStorageService) PreSignUrl(bucket string, key string, operation storage.Operation, expiry uint32) (string, error) {
+	err := r.ensureBucketExists(bucket)
+	if err != nil {
+		return "", err
+	}
+
+	return r.StorageService.PreSignUrl(bucket, key, operation, expiry)
+}
+
+func configFromEnv() (*minioConfig, error) {
+	endpoint := utils.GetEnv(MINIO_ENDPOINT_ENV, "")
+	accKey := utils.GetEnv(MINIO_ACCESS_KEY_ENV, "")
+	secKey := utils.GetEnv(MINIO_SECRET_KEY_ENV, "")
+
+	configErrors := make([]error, 0)
+
+	if endpoint == "" {
+		configErrors = append(configErrors, fmt.Errorf("%s not configured", MINIO_ENDPOINT_ENV))
+	}
+
+	if accKey == "" {
+		configErrors = append(configErrors, fmt.Errorf("%s not configured", MINIO_ACCESS_KEY_ENV))
+	}
+
+	if secKey == "" {
+		configErrors = append(configErrors, fmt.Errorf("%s not configured", MINIO_SECRET_KEY_ENV))
+	}
+
+	if len(configErrors) > 0 {
+		return nil, fmt.Errorf("configuration errors: %v", configErrors)
+	}
+
+	return &minioConfig{
+		endpoint:  endpoint,
+		accessKey: accKey,
+		secretKey: secKey,
+	}, nil
+}
+
+func nameSelector(nitricName string) (*string, error) {
+	return &nitricName, nil
+}
+
+func NewStorage() (storage.StorageService, error) {
+	conf, err := configFromEnv()
+	if err != nil {
+		return nil, err
+	}
+
+	// Configure to use MinIO Server
+	s3Config := &aws.Config{
+		Credentials:      credentials.NewStaticCredentials(conf.accessKey, conf.secretKey, ""),
+		Endpoint:         aws.String(conf.endpoint),
+		Region:           aws.String("us-east-1"),
+		DisableSSL:       aws.Bool(true),
+		S3ForcePathStyle: aws.Bool(true),
+	}
+	newSession, err := session.NewSession(s3Config)
+	if err != nil {
+		return nil, fmt.Errorf("error creating new session")
+	}
+
+	s3Client := s3.New(newSession)
+
+	s3Service, err := s3_service.NewWithClient(nil, s3Client, s3_service.WithSelector(nameSelector))
+
+	return &RunStorageService{
+		StorageService: s3Service,
+		client:         s3Client,
+	}, nil
+}

--- a/pkg/run/storage.go
+++ b/pkg/run/storage.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
+
 	"github.com/nitrictech/nitric/pkg/plugins/storage"
 	s3_service "github.com/nitrictech/nitric/pkg/plugins/storage/s3"
 	"github.com/nitrictech/nitric/pkg/utils"
@@ -157,6 +158,7 @@ func NewStorage() (storage.StorageService, error) {
 		DisableSSL:       aws.Bool(true),
 		S3ForcePathStyle: aws.Bool(true),
 	}
+
 	newSession, err := session.NewSession(s3Config)
 	if err != nil {
 		return nil, fmt.Errorf("error creating new session")
@@ -165,6 +167,9 @@ func NewStorage() (storage.StorageService, error) {
 	s3Client := s3.New(newSession)
 
 	s3Service, err := s3_service.NewWithClient(nil, s3Client, s3_service.WithSelector(nameSelector))
+	if err != nil {
+		return nil, err
+	}
 
 	return &RunStorageService{
 		StorageService: s3Service,

--- a/pkg/run/storage.go
+++ b/pkg/run/storage.go
@@ -50,7 +50,7 @@ func (r *RunStorageService) ensureBucketExists(bucket string) error {
 		Bucket: aws.String(bucket),
 	})
 
-	if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == s3.ErrCodeNoSuchBucket {
+	if _, ok := err.(awserr.Error); ok {
 		_, err = r.client.CreateBucket(&s3.CreateBucketInput{
 			Bucket:           aws.String(bucket),
 			GrantFullControl: aws.String("*"),

--- a/pkg/stack/options.go
+++ b/pkg/stack/options.go
@@ -62,7 +62,7 @@ func ConfigFromOptions() (*Config, error) {
 		} else if len(stacks) > 0 {
 			// List all the other stacks
 			err = survey.AskOne(&survey.Select{
-				Message: "Which stack do you wish to deploy?",
+				Message: "Which stack?",
 				Options: stacks,
 			}, &sName)
 


### PR DESCRIPTION
- Can now use `nitric up` on ARM based devices (i.e. M1/2 macbooks).
- Add `nitric start` a services only version of nitric for local development.