### PR TITLE
Cleanup logs when using `--ci`

### DIFF
--- a/pkg/cmd/run/root.go
+++ b/pkg/cmd/run/root.go
@@ -51,8 +51,7 @@ var runCmd = &cobra.Command{
 	Annotations: map[string]string{"commonCommand": "yes"},
 	Run: func(cmd *cobra.Command, args []string) {
 		term := make(chan os.Signal, 1)
-		signal.Notify(term, os.Interrupt, syscall.SIGTERM)
-		signal.Notify(term, os.Interrupt, syscall.SIGINT)
+		signal.Notify(term, syscall.SIGTERM, syscall.SIGINT)
 
 		// Divert default log output to pterm debug
 		log.SetOutput(output.NewPtermWriter(pterm.Debug))

--- a/pkg/cmd/run/root.go
+++ b/pkg/cmd/run/root.go
@@ -55,6 +55,7 @@ var runCmd = &cobra.Command{
 
 		// Divert default log output to pterm debug
 		log.SetOutput(output.NewPtermWriter(pterm.Debug))
+		log.SetFlags(0)
 
 		config, err := project.ConfigFromProjectPath("")
 		cobra.CheckErr(err)

--- a/pkg/cmd/stack/root.go
+++ b/pkg/cmd/stack/root.go
@@ -147,6 +147,7 @@ var stackUpdateCmd = &cobra.Command{
 		cobra.CheckErr(err)
 
 		log.SetOutput(output.NewPtermWriter(pterm.Debug))
+		log.SetFlags(0)
 
 		envFiles := utils.FilesExisting(".env", ".env.production", envFile)
 		envMap := map[string]string{}
@@ -219,6 +220,9 @@ nitric stack down -e aws -y`,
 
 		s, err := stack.ConfigFromOptions()
 		cobra.CheckErr(err)
+
+		log.SetOutput(output.NewPtermWriter(pterm.Debug))
+		log.SetFlags(0)
 
 		config, err := project.ConfigFromProjectPath("")
 		cobra.CheckErr(err)

--- a/pkg/cmd/start/root.go
+++ b/pkg/cmd/start/root.go
@@ -48,6 +48,7 @@ var startCmd = &cobra.Command{
 
 		// Divert default log output to pterm debug
 		log.SetOutput(output.NewPtermWriter(pterm.Debug))
+		log.SetFlags(0)
 
 		ls := run.NewLocalServices(&project.Project{
 			Name: "local",

--- a/pkg/cmd/start/root.go
+++ b/pkg/cmd/start/root.go
@@ -44,8 +44,7 @@ var startCmd = &cobra.Command{
 	Annotations: map[string]string{"commonCommand": "yes"},
 	Run: func(cmd *cobra.Command, args []string) {
 		term := make(chan os.Signal, 1)
-		signal.Notify(term, os.Interrupt, syscall.SIGTERM)
-		signal.Notify(term, os.Interrupt, syscall.SIGINT)
+		signal.Notify(term, syscall.SIGTERM, syscall.SIGINT)
 
 		// Divert default log output to pterm debug
 		log.SetOutput(output.NewPtermWriter(pterm.Debug))

--- a/pkg/codeconfig/codeconfig.go
+++ b/pkg/codeconfig/codeconfig.go
@@ -305,8 +305,6 @@ func useHostInterface(hc *container.HostConfig, iface string, port int) ([]strin
 		return nil, err
 	}
 
-	fmt.Println("dockerInternalAddr ", dockerInternalAddr)
-
 	hc.NetworkMode = "host"
 
 	return []string{

--- a/pkg/output/verbose.go
+++ b/pkg/output/verbose.go
@@ -45,7 +45,7 @@ func StdoutToPtermDebug(b io.ReadCloser, p Progress, prefix string) {
 		line := strings.TrimRightFunc(sc.Text(), unicode.IsSpace)
 
 		if line != "" {
-			p.Debugf("%s %v\n", prefix, line)
+			p.Debugf("%s %v", prefix, line)
 		}
 	}
 }

--- a/pkg/tasklet/tasklet.go
+++ b/pkg/tasklet/tasklet.go
@@ -50,19 +50,35 @@ type taskletContext struct {
 var _ output.Progress = &taskletContext{}
 
 func (c *taskletContext) Debugf(format string, a ...interface{}) {
-	pterm.Debug.Printf(format, a...)
+	if output.CI {
+		if output.VerboseLevel > 1 {
+			fmt.Println(fmt.Sprintf(format, a...))
+		}
+	} else {
+		pterm.Debug.Println(fmt.Sprintf(format, a...))
+	}
 }
 
 func (c *taskletContext) Busyf(format string, a ...interface{}) {
-	c.spinner.UpdateText(fmt.Sprintf(format, a...))
+	if !output.CI {
+		c.spinner.UpdateText(fmt.Sprintf(format, a...))
+	}
 }
 
 func (c *taskletContext) Successf(format string, a ...interface{}) {
-	c.spinner.SuccessPrinter.Printf(format, a...)
+	if output.CI {
+		fmt.Println(fmt.Sprintf(format, a...))
+	} else {
+		c.spinner.SuccessPrinter.Printf(format, a...)
+	}
 }
 
 func (c *taskletContext) Failf(format string, a ...interface{}) {
-	pterm.Error.Printf(format, a...)
+	if output.CI {
+		fmt.Println(fmt.Sprintf(format, a...))
+	} else {
+		pterm.Error.Printf(format, a...)
+	}
 }
 
 func MustRun(runner Runner, opts Opts) {


### PR DESCRIPTION
example
```
nitric stack up  -s test4 -v1 --ci
building nitric v1.8.0-71-g5d288f405316d5598a31932b0960f8bab3ea52bc-dirty
Gathering configuration from code..                                                                                                                                                                                                        
SUCCESS: Configuration gathered (1s)                                                                                                                                                                                                       
Deploying..                                                                                                                                                                                                                                
Group/nitric-todo-test4 (1s)
Role/tasksLambdaRole (2s)
RolePolicyAttachment/tasksLambdaBasicExecution (1s)
RolePolicy/tasksListAccess (1s)
Image/tasks-image (5s)
Table/task-collection (7s)
RolePolicy/tasks-c0c5f70007b3733c39d198bd674bbde4 (1s)
Function/tasks (48s)
Api/task-list (4s)
Permission/task-listtasks (0s)
Stage/task-listDefaultStage (1s)
build results written to: /home/angus/.nitric/stacks/nitric-todo-test4.results.json
Deployed: Stack (1m4s)                                                                                                                                                                                                                     
┌─────────────────────────────────────────────────────────────────────────┐
| API       | Endpoint                                                    |
| task-list | https://wrbnofsfsk.execute-api.ap-southeast-2.amazonaws.com |
└─────────────────────────────────────────────────────────────────────────┘
```