### PR TITLE
fix: make NITRIC_ENVIRONMENT=(build, run, cloud) consistent

### DIFF
--- a/pkg/provider/pulumi/aws/lambda.go
+++ b/pkg/provider/pulumi/aws/lambda.go
@@ -130,8 +130,9 @@ func newLambda(ctx *pulumi.Context, name string, args *LambdaArgs, opts ...pulum
 	}
 
 	envVars := pulumi.StringMap{
-		"NITRIC_STACK": pulumi.String(args.StackName),
-		"MIN_WORKERS":  pulumi.String(fmt.Sprint(args.Compute.Workers())),
+		"NITRIC_ENVIRONMENT": pulumi.String("cloud"),
+		"NITRIC_STACK":       pulumi.String(args.StackName),
+		"MIN_WORKERS":        pulumi.String(fmt.Sprint(args.Compute.Workers())),
 	}
 	for k, v := range args.EnvMap {
 		envVars[k] = pulumi.String(v)

--- a/pkg/provider/pulumi/azure/containerapp.go
+++ b/pkg/provider/pulumi/azure/containerapp.go
@@ -291,6 +291,10 @@ func (a *azureProvider) newContainerApp(ctx *pulumi.Context, name string, args *
 
 	env := app.EnvironmentVarArray{
 		app.EnvironmentVarArgs{
+			Name:  pulumi.String("NITRIC_ENVIRONMENT"),
+			Value: pulumi.String("cloud"),
+		},
+		app.EnvironmentVarArgs{
 			Name:  pulumi.String("MIN_WORKERS"),
 			Value: pulumi.String(fmt.Sprint(args.Compute.Workers())),
 		},

--- a/pkg/provider/pulumi/gcp/cloudrunner.go
+++ b/pkg/provider/pulumi/gcp/cloudrunner.go
@@ -62,6 +62,10 @@ func (g *gcpProvider) newCloudRunner(ctx *pulumi.Context, name string, args *Clo
 
 	env := cloudrun.ServiceTemplateSpecContainerEnvArray{
 		cloudrun.ServiceTemplateSpecContainerEnvArgs{
+			Name:  pulumi.String("NITRIC_ENVIRONMENT"),
+			Value: pulumi.String("cloud"),
+		},
+		cloudrun.ServiceTemplateSpecContainerEnvArgs{
 			Name:  pulumi.String("MIN_WORKERS"),
 			Value: pulumi.String(fmt.Sprint(args.Compute.Workers())),
 		},

--- a/pkg/run/function.go
+++ b/pkg/run/function.go
@@ -62,6 +62,7 @@ func (f *Function) Start(envMap map[string]string) error {
 	}
 
 	env := []string{
+		"NITRIC_ENVIRONMENT=run",
 		fmt.Sprintf("SERVICE_ADDRESS=host.docker.internal:%d", 50051),
 		fmt.Sprintf("NITRIC_SERVICE_PORT=%d", 50051),
 		fmt.Sprintf("NITRIC_SERVICE_HOST=%s", "host.docker.internal"),


### PR DESCRIPTION
This means that the only environment that won't have it set will be when using 'nitric start'.

It is important to know when connecting to extenal services in the cloud or DBs what environment we are running in.