### PR TITLE
Enable delayed pubsub messages via cloud tasks

### DIFF
--- a/pkg/provider/pulumi/gcp/cloudrunner.go
+++ b/pkg/provider/pulumi/gcp/cloudrunner.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/cloudrun"
+	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/cloudtasks"
 	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/pubsub"
 	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/serviceaccount"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -38,6 +39,7 @@ type CloudRunnerArgs struct {
 	EnvMap         map[string]string
 	ServiceAccount *serviceaccount.Account
 	Topics         map[string]*pubsub.Topic
+	DelayQueue     *cloudtasks.Queue
 }
 
 type CloudRunner struct {
@@ -73,6 +75,18 @@ func (g *gcpProvider) newCloudRunner(ctx *pulumi.Context, name string, args *Clo
 			Name:  pulumi.String("NITRIC_STACK"),
 			Value: pulumi.String(ctx.Stack()),
 		},
+		cloudrun.ServiceTemplateSpecContainerEnvArgs{
+			Name:  pulumi.String("SERVICE_ACCOUNT_EMAIL"),
+			Value: args.ServiceAccount.Email,
+		},
+	}
+
+	// Ensure functions are aware of the delay queue
+	if args.DelayQueue != nil {
+		env = append(env, cloudrun.ServiceTemplateSpecContainerEnvArgs{
+			Name:  pulumi.String("DELAY_QUEUE_NAME"),
+			Value: pulumi.Sprintf("projects/%s/locations/%s/queues/%s", args.DelayQueue.Project, args.DelayQueue.Location, args.DelayQueue.Name),
+		})
 	}
 
 	for k, v := range args.EnvMap {

--- a/pkg/provider/pulumi/gcp/gcp.go
+++ b/pkg/provider/pulumi/gcp/gcp.go
@@ -354,10 +354,6 @@ func (g *gcpProvider) Deploy(ctx *pulumi.Context) error {
 	}
 
 	for key := range g.proj.Topics {
-		if err != nil {
-			return err
-		}
-
 		g.topics[key], err = pubsub.NewTopic(ctx, key, &pubsub.TopicArgs{
 			Name:   pulumi.String(key),
 			Labels: common.Tags(ctx, key),

--- a/pkg/provider/pulumi/gcp/gcp.go
+++ b/pkg/provider/pulumi/gcp/gcp.go
@@ -33,6 +33,7 @@ import (
 	multierror "github.com/missionMeteora/toolkit/errors"
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/cloudscheduler"
+	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/cloudtasks"
 	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/organizations"
 	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/projects"
 	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/pubsub"
@@ -339,7 +340,24 @@ func (g *gcpProvider) Deploy(ctx *pulumi.Context) error {
 		}
 	}
 
+	var topicDelayQueue *cloudtasks.Queue
+	if len(g.proj.Topics) > 0 {
+		// create a shared queue for enabling delayed messaging
+		// cloud run functions will create OIDC tokens for their own service accounts
+		// to apply to push actions to pubsub, so their scope should still be limited to that
+		topicDelayQueue, err = cloudtasks.NewQueue(ctx, "delay-queue", &cloudtasks.QueueArgs{
+			Location: pulumi.String(g.sc.Region),
+		})
+		if err != nil {
+			return err
+		}
+	}
+
 	for key := range g.proj.Topics {
+		if err != nil {
+			return err
+		}
+
 		g.topics[key], err = pubsub.NewTopic(ctx, key, &pubsub.TopicArgs{
 			Name:   pulumi.String(key),
 			Labels: common.Tags(ctx, key),
@@ -433,6 +451,8 @@ func (g *gcpProvider) Deploy(ctx *pulumi.Context) error {
 		Permissions: pulumi.ToStringArray([]string{
 			"storage.buckets.list",
 			"storage.buckets.get",
+			"cloudtasks.queues.get",
+			"cloudtasks.tasks.create",
 			// permission for blob signing
 			// this is safe as only permissions this account has are delegated
 			"iam.serviceAccounts.signBlob",
@@ -479,6 +499,16 @@ func (g *gcpProvider) Deploy(ctx *pulumi.Context) error {
 			return errors.WithMessage(err, "function project membership "+c.Unit().Name)
 		}
 
+		// give the service account permission to use itself
+		_, err = serviceaccount.NewIAMMember(ctx, c.Unit().Name+"-acct-member", &serviceaccount.IAMMemberArgs{
+			ServiceAccountId: sa.Name,
+			Member:           pulumi.Sprintf("serviceAccount:%s", sa.Email),
+			Role:             pulumi.String("roles/iam.serviceAccountUser"),
+		})
+		if err != nil {
+			return errors.WithMessage(err, "service account self membership "+c.Unit().Name)
+		}
+
 		g.cloudRunners[c.Unit().Name], err = g.newCloudRunner(ctx, c.Unit().Name, &CloudRunnerArgs{
 			Location:       pulumi.String(g.sc.Region),
 			ProjectId:      g.projectId,
@@ -487,6 +517,7 @@ func (g *gcpProvider) Deploy(ctx *pulumi.Context) error {
 			Image:          g.images[c.Unit().Name],
 			ServiceAccount: sa,
 			EnvMap:         g.envMap,
+			DelayQueue:     topicDelayQueue,
 		}, defaultResourceOptions)
 		if err != nil {
 			return err


### PR DESCRIPTION
Adds base infrastructure. Membrane needs to be upgraded to finalise functionality.