### PR TITLE
Add server.Details() implementation for code discovery

### DIFF
--- a/pkg/codeconfig/server.go
+++ b/pkg/codeconfig/server.go
@@ -18,6 +18,7 @@ package codeconfig
 
 import (
 	"context"
+	"fmt"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -86,6 +87,24 @@ func (s *Server) Declare(ctx context.Context, req *pb.ResourceDeclareRequest) (*
 	}
 
 	return &pb.ResourceDeclareResponse{}, nil
+}
+
+func (s *Server) Details(ctx context.Context, req *pb.ResourceDetailsRequest) (*pb.ResourceDetailsResponse, error) {
+	switch req.Resource.Type {
+	case pb.ResourceType_Api:
+		return &pb.ResourceDetailsResponse{
+			Provider: "dev",
+			Service:  "Api",
+			Id:       req.Resource.Name,
+			Details: &pb.ResourceDetailsResponse_Api{
+				Api: &pb.ApiResourceDetails{
+					Url: "http://localhost:50051/apis/" + req.Resource.Name,
+				},
+			},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported resource type %s", req.Resource.Type)
+	}
 }
 
 // NewServer - Creates a new deployment server

--- a/pkg/run/resources.go
+++ b/pkg/run/resources.go
@@ -44,7 +44,7 @@ func (r *RunResourcesService) Details(typ common.ResourceType, name string) (*co
 	case common.ResourceType_Api:
 		return r.getApiDetails(name)
 	default:
-		return nil, fmt.Errorf("unsupported resoruce type %s", typ)
+		return nil, fmt.Errorf("unsupported resource type %s", typ)
 	}
 }
 


### PR DESCRIPTION
Right now if you call `myApi.Details()` it will fail with not implemented in the config discovery phase.