### PR TITLE
Shim pulumi using docker if not on path

### DIFF
--- a/pkg/provider/pulumi/generator.go
+++ b/pkg/provider/pulumi/generator.go
@@ -75,6 +75,7 @@ func New(p *project.Project, name, provider string, envMap map[string]string, op
 	if err != nil {
 		return nil, err
 	}
+
 	pv := exec.Command("pulumi", "version")
 
 	err = pv.Run()
@@ -148,6 +149,7 @@ func shimPulumi() error {
 
 		// login to pulumi locally
 		cmd := exec.Command("pulumi", "whoami")
+
 		err = cmd.Run()
 		if err != nil {
 			// login to pulumi locally by default

--- a/pkg/provider/pulumi/pulumi-shim.sh
+++ b/pkg/provider/pulumi/pulumi-shim.sh
@@ -1,17 +1,25 @@
 #!/bin/bash
 
+# This script runs a pulumi as a container compatible with
+# the pulumi automation API.
+
+# This script should only be run in the absence of a local pulumi installation
+
 cmd="$@";
 
 docker run \
+    --rm \
 	--network="host" \
 	-v $HOME/.pulumi:/root/.pulumi \
 	-v $HOME:$HOME \
 	-v $HOME/.aws:/root/.aws \
+    -v $HOME/.config/gclod:/root/.config/gcloud \
+    -v $HOME/.azure:/root/.azure \
 	-v /var/run/docker.sock:/var/run/docker.sock \
 	-v $(pwd):/app \
 	-e PULUMI_HOME=/root/.pulumi \
 	-e PULUMI_CONFIG_PASSPHRASE_FILE=$PULUMI_CONFIG_PASSPHRASE_FILE \
 	-e PULUMI_DEBUG_COMMANDS=true \
 	-w /app \
-    pulumi/pulumi:3.43.1 \
+    pulumi/pulumi \
     $cmd

--- a/pkg/provider/pulumi/pulumi-shim.sh
+++ b/pkg/provider/pulumi/pulumi-shim.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+cmd="$@";
+
+docker run \
+	--network="host" \
+	-v $HOME/.pulumi:/root/.pulumi \
+	-v $HOME:$HOME \
+	-v $HOME/.aws:/root/.aws \
+	-v /var/run/docker.sock:/var/run/docker.sock \
+	-v $(pwd):/app \
+	-e PULUMI_HOME=/root/.pulumi \
+	-e PULUMI_CONFIG_PASSPHRASE_FILE=$PULUMI_CONFIG_PASSPHRASE_FILE \
+	-e PULUMI_DEBUG_COMMANDS=true \
+	-w /app \
+    pulumi/pulumi:3.43.1 \
+    $cmd

--- a/pkg/provider/pulumi/pulumi-shim.sh
+++ b/pkg/provider/pulumi/pulumi-shim.sh
@@ -9,17 +9,17 @@ cmd="$@";
 
 docker run \
     --rm \
-	--network="host" \
-	-v $HOME/.pulumi:/root/.pulumi \
-	-v $HOME:$HOME \
-	-v $HOME/.aws:/root/.aws \
+    --network="host" \
+    -v $HOME/.pulumi:/root/.pulumi \
+    -v $HOME:$HOME \
+    -v $HOME/.aws:/root/.aws \
     -v $HOME/.config/gclod:/root/.config/gcloud \
     -v $HOME/.azure:/root/.azure \
-	-v /var/run/docker.sock:/var/run/docker.sock \
-	-v $(pwd):/app \
-	-e PULUMI_HOME=/root/.pulumi \
-	-e PULUMI_CONFIG_PASSPHRASE_FILE=$PULUMI_CONFIG_PASSPHRASE_FILE \
-	-e PULUMI_DEBUG_COMMANDS=true \
-	-w /app \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v $(pwd):/app \
+    -e PULUMI_HOME=/root/.pulumi \
+    -e PULUMI_CONFIG_PASSPHRASE_FILE=$PULUMI_CONFIG_PASSPHRASE_FILE \
+    -e PULUMI_DEBUG_COMMANDS=true \
+    -w /app \
     pulumi/pulumi \
     $cmd


### PR DESCRIPTION
This needs some extensive testing on multiple platforms. And fresh installs

Still need to write a shim for windows (currently this will only work on linux/macos).

We should probably provide warnings for the login local stuff as well. And for more serious usage recommend installing pulumi locally.