### PR TITLE
Make API and trigger ports dynamic

### DIFF
--- a/.github/workflows/local-run.yaml
+++ b/.github/workflows/local-run.yaml
@@ -47,7 +47,7 @@ jobs:
           cd ${{ github.workspace }}/test-app
           make test
         env:
-          BASE_URL: http://localhost:49153
+          BASE_URL: http://localhost:4001
 
       - name: Archive logfile
         uses: actions/upload-artifact@v3

--- a/.github/workflows/local-run.yaml
+++ b/.github/workflows/local-run.yaml
@@ -48,6 +48,7 @@ jobs:
           make test
         env:
           BASE_URL: http://localhost:4001
+          TOPIC_BASE_URL: "http://localhost:4000/topic"
 
       - name: Archive logfile
         uses: actions/upload-artifact@v3

--- a/.github/workflows/local-run.yaml
+++ b/.github/workflows/local-run.yaml
@@ -46,6 +46,8 @@ jobs:
         run: |
           cd ${{ github.workspace }}/test-app
           make test
+        env:
+          BASE_URL: http://localhost:49153
 
       - name: Archive logfile
         uses: actions/upload-artifact@v3

--- a/pkg/cmd/run/root.go
+++ b/pkg/cmd/run/root.go
@@ -147,6 +147,13 @@ var runCmd = &cobra.Command{
 
 		stackState := run.NewStackState()
 
+		err = ls.Refresh()
+		if err != nil {
+			cobra.CheckErr(err)
+		}
+
+		stackState.Update(pool, ls)
+
 		area, _ := pterm.DefaultArea.Start()
 		area.Update(stackState.Tables(9001))
 
@@ -155,11 +162,14 @@ var runCmd = &cobra.Command{
 		pool.Listen(func(we run.WorkerEvent) {
 			lck.Lock()
 			defer lck.Unlock()
-			// area.Clear()
 
-			ls.Refresh()
+			err := ls.Refresh()
+			if err != nil {
+				cobra.CheckErr(err)
+			}
 
 			stackState.Update(pool, ls)
+
 			area.Update(stackState.Tables(9001))
 		})
 

--- a/pkg/cmd/run/root.go
+++ b/pkg/cmd/run/root.go
@@ -145,7 +145,7 @@ var runCmd = &cobra.Command{
 
 		pterm.DefaultBasicText.Println("Application running, use ctrl-C to stop")
 
-		stackState := run.StateFromPool(pool)
+		stackState := run.NewStackState()
 
 		area, _ := pterm.DefaultArea.Start()
 		area.Update(stackState.Tables(9001))
@@ -157,7 +157,9 @@ var runCmd = &cobra.Command{
 			defer lck.Unlock()
 			// area.Clear()
 
-			stackState.UpdateFromWorkerEvent(we)
+			ls.Refresh()
+
+			stackState.Update(pool, ls)
 			area.Update(stackState.Tables(9001))
 		})
 

--- a/pkg/cmd/start/root.go
+++ b/pkg/cmd/start/root.go
@@ -103,7 +103,13 @@ var startCmd = &cobra.Command{
 			defer lck.Unlock()
 			// area.Clear()
 
-			stackState.UpdateFromWorkerEvent(we)
+			err := ls.Refresh()
+			if err != nil {
+				cobra.CheckErr(err)
+			}
+
+			area.Update(err)
+			stackState.Update(pool, ls)
 
 			tables := []string{}
 			table, rows := stackState.ApiTable(9001)

--- a/pkg/cmd/start/root.go
+++ b/pkg/cmd/start/root.go
@@ -21,7 +21,6 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -108,25 +107,9 @@ var startCmd = &cobra.Command{
 				cobra.CheckErr(err)
 			}
 
-			area.Update(err)
 			stackState.Update(pool, ls)
 
-			tables := []string{}
-			table, rows := stackState.ApiTable(9001)
-			if rows > 0 {
-				tables = append(tables, table)
-			}
-
-			table, rows = stackState.TopicTable(9001)
-			if rows > 0 {
-				tables = append(tables, table)
-			}
-
-			table, rows = stackState.SchedulesTable(9001)
-			if rows > 0 {
-				tables = append(tables, table)
-			}
-			area.Update(strings.Join(tables, "\n\n"))
+			area.Update(stackState.Tables(9001))
 		})
 
 		select {

--- a/pkg/run/gateway.go
+++ b/pkg/run/gateway.go
@@ -19,27 +19,38 @@ package run
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
 	"github.com/fasthttp/router"
 	"github.com/valyala/fasthttp"
 
+	"github.com/nitrictech/cli/pkg/utils"
 	"github.com/nitrictech/nitric/pkg/plugins/gateway"
 	"github.com/nitrictech/nitric/pkg/triggers"
-	nitric_utils "github.com/nitrictech/nitric/pkg/utils"
 	"github.com/nitrictech/nitric/pkg/worker"
 )
 
 type HttpMiddleware func(*fasthttp.RequestCtx, worker.WorkerPool) bool
 
-type BaseHttpGateway struct {
-	address string
-	server  *fasthttp.Server
-	gateway.UnimplementedGatewayPlugin
+type apiServer struct {
+	lis net.Listener
+	srv *fasthttp.Server
 
+	workerCount int
+}
+
+type BaseHttpGateway struct {
+	apiServer       map[string]*apiServer
+	serviceServer   *fasthttp.Server
+	serviceListener net.Listener
+	gateway.UnimplementedGatewayPlugin
+	stop chan bool
 	pool worker.WorkerPool
 }
+
+var _ gateway.GatewayService = &BaseHttpGateway{}
 
 func apiWorkerFilter(apiName string) func(w worker.Worker) bool {
 	return func(w worker.Worker) bool {
@@ -51,44 +62,54 @@ func apiWorkerFilter(apiName string) func(w worker.Worker) bool {
 	}
 }
 
-func (s *BaseHttpGateway) api(ctx *fasthttp.RequestCtx) {
-	apiName := ctx.UserValue("name").(string)
-	// Rewrite the URL of the request to remove the /api/{name} subroute
-	pathParts := nitric_utils.SplitPath(string(ctx.URI().PathOriginal()))
-
-	// remove first two path parts
-	newPathParts := pathParts[2:]
-
-	newPath := strings.Join(newPathParts, "/")
-
-	// Rewrite the path
-	ctx.URI().SetPath(newPath)
-
-	httpReq := triggers.FromHttpRequest(ctx)
-
-	worker, err := s.pool.GetWorker(&worker.GetWorkerOptions{
-		Http:   httpReq,
-		Filter: apiWorkerFilter(apiName),
-	})
-	if err != nil {
-		ctx.Error("No workers found for provided API route", 404)
-		return
+// GetTriggerAddress - Returns the address built-in nitric services
+// this can be used to publishing messages to topics or triggering schedules
+func (s *BaseHttpGateway) GetTriggerAddress() string {
+	if s.serviceListener != nil {
+		return strings.Replace(s.serviceListener.Addr().String(), "127.0.0.1", "localhost", 1)
 	}
 
-	resp, err := worker.HandleHttpRequest(context.TODO(), httpReq)
-	if err != nil {
-		ctx.Error(fmt.Sprintf("Error handling HTTP Request: %v", err), 500)
-		return
+	return ""
+}
+
+func (s *BaseHttpGateway) GetApiAdresses() map[string]string {
+	addresses := make(map[string]string)
+	for api, srv := range s.apiServer {
+		if srv.workerCount > 0 {
+			srvAddress := strings.Replace(srv.lis.Addr().String(), "127.0.0.1", "localhost", 1)
+			addresses[api] = srvAddress
+		}
 	}
 
-	if resp.Header != nil {
-		resp.Header.CopyTo(&ctx.Response.Header)
-	}
+	return addresses
+}
 
-	// Avoid content length header duplication
-	ctx.Response.Header.Del("Content-Length")
-	ctx.Response.SetStatusCode(resp.StatusCode)
-	ctx.Response.SetBody(resp.Body)
+func (s *BaseHttpGateway) api(apiName string) func(ctx *fasthttp.RequestCtx) {
+	return func(ctx *fasthttp.RequestCtx) {
+		httpReq := triggers.FromHttpRequest(ctx)
+
+		worker, err := s.pool.GetWorker(&worker.GetWorkerOptions{
+			Http:   httpReq,
+			Filter: apiWorkerFilter(apiName),
+		})
+		if err != nil {
+			ctx.Error("No workers found for provided API route", 404)
+			return
+		}
+
+		resp, err := worker.HandleHttpRequest(context.TODO(), httpReq)
+		if err != nil {
+			ctx.Error(fmt.Sprintf("Error handling HTTP Request: %v", err), 500)
+			return
+		}
+
+		if resp.Header != nil {
+			resp.Header.CopyTo(&ctx.Response.Header)
+		}
+
+		ctx.Response.SetBody(resp.Body)
+		ctx.Response.SetStatusCode(resp.StatusCode)
+	}
 }
 
 func (s *BaseHttpGateway) topic(ctx *fasthttp.RequestCtx) {
@@ -119,38 +140,114 @@ func (s *BaseHttpGateway) topic(ctx *fasthttp.RequestCtx) {
 	ctx.Success("text/plain", []byte(fmt.Sprintf("%d successful & %d failed deliveries", len(ws)-len(errList), len(errList))))
 }
 
+// Update the gateway and API based on the worker pool
+func (s *BaseHttpGateway) Refresh() error {
+	// instansiate servers if not already done
+	if s.apiServer == nil {
+		s.apiServer = make(map[string]*apiServer)
+	}
+
+	for _, srv := range s.apiServer {
+		// reset all server worker counts
+		srv.workerCount = 0
+	}
+
+	for _, w := range s.pool.GetWorkers(&worker.GetWorkerOptions{}) {
+		if api, ok := w.(*worker.RouteWorker); ok {
+			currApi, ok := s.apiServer[api.Api()]
+
+			if !ok {
+				fhttp := &fasthttp.Server{
+					ReadTimeout:     time.Second * 1,
+					IdleTimeout:     time.Second * 1,
+					CloseOnShutdown: true,
+					Handler:         s.api(api.Api()),
+				}
+
+				lis, err := utils.GetNextListener()
+				if err != nil {
+					return err
+				}
+
+				srv := &apiServer{
+					lis:         lis,
+					srv:         fhttp,
+					workerCount: 0,
+				}
+
+				// get a free port and listen on that for this API
+				go func(srv *apiServer) {
+					err := srv.srv.Serve(srv.lis)
+					if err != nil {
+						fmt.Println(err)
+					}
+				}(srv)
+
+				currApi = srv
+				// append to the server collection
+				s.apiServer[api.Api()] = currApi
+
+				// this is a brand new server we need to start up
+				// lets start it and add it to the active list of servers
+				// we can then filter the servers by their active worker count
+				currApi.workerCount = 0
+			}
+
+			// Increment this APIs worker count
+			// this will be used to filter displayed APIs
+			currApi.workerCount = currApi.workerCount + 1
+		}
+	}
+
+	return nil
+}
+
 func (s *BaseHttpGateway) Start(pool worker.WorkerPool) error {
+	var err error
+	// Assign the pool and block
 	s.pool = pool
+	s.stop = make(chan bool)
 
 	// Setup routes
 	r := router.New()
-	// Make a request to an API gateway
-	r.ANY("/apis/{name}/{any?:*}", s.api)
 	// Publish to a topic
 	r.POST("/topic/{name}", s.topic)
 
-	s.server = &fasthttp.Server{
+	s.serviceServer = &fasthttp.Server{
 		ReadTimeout:     time.Second * 1,
 		IdleTimeout:     time.Second * 1,
 		CloseOnShutdown: true,
 		Handler:         r.Handler,
 	}
 
-	return s.server.ListenAndServe(s.address)
+	s.serviceListener, err = utils.GetNextListener()
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		s.serviceServer.Serve(s.serviceListener)
+	}()
+
+	// block on a stop signal
+	<-s.stop
+
+	return nil
 }
 
 func (s *BaseHttpGateway) Stop() error {
-	if s.server != nil {
-		return s.server.Shutdown()
+	for _, s := range s.apiServer {
+		// shutdown all the servers
+		// this will allow Start to exit
+		s.srv.Shutdown()
 	}
 
+	s.stop <- true
 	return nil
 }
 
 // Create new HTTP gateway
 // XXX: No External Args for function atm (currently the plugin loader does not pass any argument information)
-func NewGateway(address string) (gateway.GatewayService, error) {
-	return &BaseHttpGateway{
-		address: address,
-	}, nil
+func NewGateway() (*BaseHttpGateway, error) {
+	return &BaseHttpGateway{}, nil
 }

--- a/pkg/run/gateway.go
+++ b/pkg/run/gateway.go
@@ -74,6 +74,7 @@ func (s *BaseHttpGateway) GetTriggerAddress() string {
 
 func (s *BaseHttpGateway) GetApiAdresses() map[string]string {
 	addresses := make(map[string]string)
+
 	for api, srv := range s.apiServer {
 		if srv.workerCount > 0 {
 			srvAddress := strings.Replace(srv.lis.Addr().String(), "127.0.0.1", "localhost", 1)
@@ -226,7 +227,7 @@ func (s *BaseHttpGateway) Start(pool worker.WorkerPool) error {
 	}
 
 	go func() {
-		s.serviceServer.Serve(s.serviceListener)
+		_ = s.serviceServer.Serve(s.serviceListener)
 	}()
 
 	// block on a stop signal
@@ -239,10 +240,11 @@ func (s *BaseHttpGateway) Stop() error {
 	for _, s := range s.apiServer {
 		// shutdown all the servers
 		// this will allow Start to exit
-		s.srv.Shutdown()
+		_ = s.srv.Shutdown()
 	}
 
 	s.stop <- true
+
 	return nil
 }
 

--- a/pkg/run/resources.go
+++ b/pkg/run/resources.go
@@ -24,18 +24,24 @@ import (
 )
 
 type RunResourcesService struct {
-	gatewayUri string
+	// gatewayUri string
+	gatewayUris map[string]string
 }
 
 var _ common.ResourceService = &RunResourcesService{}
 
 func (r *RunResourcesService) getApiDetails(name string) (*common.DetailsResponse[any], error) {
+	gatewayUri, ok := r.gatewayUris[name]
+	if !ok {
+		return nil, fmt.Errorf("api %s does not exist", name)
+	}
+
 	return &common.DetailsResponse[any]{
 		Id:       name,
 		Provider: "dev",
 		Service:  "Api",
 		Detail: common.ApiDetails{
-			URL: fmt.Sprintf("%s/apis/%s", r.gatewayUri, name),
+			URL: gatewayUri,
 		},
 	}, nil
 }
@@ -49,8 +55,8 @@ func (r *RunResourcesService) Details(ctx context.Context, typ common.ResourceTy
 	}
 }
 
-func NewResources(gatewayUri string) common.ResourceService {
+func NewResources(gatewayUris map[string]string) common.ResourceService {
 	return &RunResourcesService{
-		gatewayUri: gatewayUri,
+		gatewayUris: gatewayUris,
 	}
 }

--- a/pkg/run/stack.go
+++ b/pkg/run/stack.go
@@ -26,104 +26,29 @@ import (
 )
 
 type RunStackState struct {
-	apis      map[string]int
-	subs      map[string]int
-	schedules map[string]int
+	apis      map[string]string
+	subs      map[string]string
+	schedules map[string]string
 }
 
-func StateFromPool(pool worker.WorkerPool) *RunStackState {
-	r := NewStackState()
-	wrkrs := pool.GetWorkers(&worker.GetWorkerOptions{})
+func (r *RunStackState) Update(pool worker.WorkerPool, ls LocalServices) {
+	// reset state maps
+	r.apis = make(map[string]string)
+	r.subs = make(map[string]string)
+	r.schedules = make(map[string]string)
 
-	for _, wrkr := range wrkrs {
-		switch wrkr.(type) {
-		case *worker.RouteWorker:
-			w := wrkr.(*worker.RouteWorker)
-
-			if _, ok := r.apis[w.Api()]; !ok {
-				r.apis[w.Api()] = 1
-			} else {
-				r.apis[w.Api()] = r.apis[w.Api()] + 1
-			}
-		case *worker.SubscriptionWorker:
-			w := wrkr.(*worker.SubscriptionWorker)
-
-			if _, ok := r.subs[w.Topic()]; !ok {
-				r.subs[w.Topic()] = 1
-			} else {
-				r.subs[w.Topic()] = r.subs[w.Topic()] + 1
-			}
-		case *worker.ScheduleWorker:
-			w := wrkr.(*worker.ScheduleWorker)
-
-			if _, ok := r.schedules[w.Key()]; !ok {
-				r.schedules[w.Key()] = 1
-			} else {
-				r.schedules[w.Key()] = r.schedules[w.Key()] + 1
-			}
-		}
+	for name, address := range ls.Apis() {
+		r.apis[name] = address
 	}
 
-	return r
-}
-
-func (r *RunStackState) UpdateFromWorkerEvent(evt WorkerEvent) {
-	if evt.Type == WorkerEventType_Add {
-		switch evt.Worker.(type) {
-		case *worker.RouteWorker:
-			w := evt.Worker.(*worker.RouteWorker)
-
-			if _, ok := r.apis[w.Api()]; !ok {
-				r.apis[w.Api()] = 1
-			} else {
-				r.apis[w.Api()] = r.apis[w.Api()] + 1
-			}
+	// TODO: We can probably move this directly into local service state
+	for _, wrkr := range pool.GetWorkers(&worker.GetWorkerOptions{}) {
+		switch w := wrkr.(type) {
 		case *worker.SubscriptionWorker:
-			w := evt.Worker.(*worker.SubscriptionWorker)
-
-			if _, ok := r.subs[w.Topic()]; !ok {
-				r.subs[w.Topic()] = 1
-			} else {
-				r.subs[w.Topic()] = r.subs[w.Topic()] + 1
-			}
+			r.subs[w.Topic()] = fmt.Sprintf("http://%s/topics/%s", ls.TriggerAddress(), w.Topic())
 		case *worker.ScheduleWorker:
-			w := evt.Worker.(*worker.ScheduleWorker)
-
-			if _, ok := r.schedules[w.Key()]; !ok {
-				r.schedules[w.Key()] = 1
-			} else {
-				r.schedules[w.Key()] = r.schedules[w.Key()] + 1
-			}
-		}
-	} else if evt.Type == WorkerEventType_Remove {
-		switch evt.Worker.(type) {
-		case *worker.RouteWorker:
-			w := evt.Worker.(*worker.RouteWorker)
-
-			r.apis[w.Api()] = r.apis[w.Api()] - 1
-
-			if r.apis[w.Api()] <= 0 {
-				// Remove the key if the reference count is 0 or less
-				delete(r.apis, w.Api())
-			}
-		case *worker.SubscriptionWorker:
-			w := evt.Worker.(*worker.SubscriptionWorker)
-
-			r.subs[w.Topic()] = r.subs[w.Topic()] - 1
-
-			if r.subs[w.Topic()] <= 0 {
-				// Remove the key if the reference count is 0 or less
-				delete(r.subs, w.Topic())
-			}
-		case *worker.ScheduleWorker:
-			w := evt.Worker.(*worker.ScheduleWorker)
-
-			r.schedules[w.Key()] = r.schedules[w.Key()] - 1
-
-			if r.schedules[w.Key()] <= 0 {
-				// Remove the key if the reference count is 0 or less
-				delete(r.schedules, w.Key())
-			}
+			topicKey := strings.ToLower(strings.ReplaceAll(w.Key(), " ", "-"))
+			r.subs[w.Key()] = fmt.Sprintf("http://%s/topics/%s", ls.TriggerAddress(), topicKey)
 		}
 	}
 }
@@ -152,9 +77,9 @@ func (r *RunStackState) Tables(port int) string {
 func (r *RunStackState) ApiTable(port int) (string, int) {
 	tableData := pterm.TableData{{"Api", "Endpoint"}}
 
-	for k := range r.apis {
+	for name, address := range r.apis {
 		tableData = append(tableData, []string{
-			k, fmt.Sprintf("http://localhost:%d/apis/%s", port, k),
+			name, fmt.Sprintf("http://%s", address),
 		})
 	}
 
@@ -166,9 +91,9 @@ func (r *RunStackState) ApiTable(port int) (string, int) {
 func (r *RunStackState) TopicTable(port int) (string, int) {
 	tableData := pterm.TableData{{"Topic", "Endpoint"}}
 
-	for k := range r.subs {
+	for k, address := range r.subs {
 		tableData = append(tableData, []string{
-			k, fmt.Sprintf("http://localhost:%d/topic/%s", port, k),
+			k, address,
 		})
 	}
 
@@ -180,10 +105,9 @@ func (r *RunStackState) TopicTable(port int) (string, int) {
 func (r *RunStackState) SchedulesTable(port int) (string, int) {
 	tableData := pterm.TableData{{"Schedule", "Endpoint"}}
 
-	for k := range r.schedules {
-		nKey := strings.ToLower(strings.ReplaceAll(k, " ", "-"))
+	for k, address := range r.schedules {
 		tableData = append(tableData, []string{
-			k, fmt.Sprintf("http://localhost:%d/topic/%s", port, nKey),
+			k, address,
 		})
 	}
 
@@ -194,8 +118,8 @@ func (r *RunStackState) SchedulesTable(port int) (string, int) {
 
 func NewStackState() *RunStackState {
 	return &RunStackState{
-		apis:      map[string]int{},
-		subs:      map[string]int{},
-		schedules: map[string]int{},
+		apis:      map[string]string{},
+		subs:      map[string]string{},
+		schedules: map[string]string{},
 	}
 }

--- a/pkg/utils/net.go
+++ b/pkg/utils/net.go
@@ -31,8 +31,8 @@ type getNextListenerOption = func(opts *getNextListenerOptions)
 func defaultGetNextListenerOptions() *getNextListenerOptions {
 	// Defaults to IANA recommended ephemeral port range of 49152–65535
 	return &getNextListenerOptions{
-		minPort: 49152,
-		maxPort: 65535,
+		minPort: 4000,
+		maxPort: 6000,
 	}
 }
 

--- a/pkg/utils/net.go
+++ b/pkg/utils/net.go
@@ -64,7 +64,6 @@ func GetNextListener(opts ...getNextListenerOption) (net.Listener, error) {
 	for currentPort < options.maxPort {
 		// attempt to get listener for port
 		lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", currentPort))
-
 		if err != nil {
 			// increment the port and continue
 			currentPort = currentPort + 1


### PR DESCRIPTION
Example output for feedback:
![image](https://user-images.githubusercontent.com/13415171/204199265-b5cccf68-5dd9-466a-b66c-5481ba17540d.png)

Because we're supporting hot-reloading and the number of workers can change at any time, supporting alphabetical ordering of ports its a bit trickier (but not impossible).

At the moment all ports will be consistently held under their names for the lifetime of a single `nitric start`.
