### PR TITLE
chore: update Dockerfile to reduce the image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ENV DOCKER_PASS_CH v0.6.4
 
 # Install deps all in one step
 RUN apt-get update -y && \
-  apt-get install -y \
+  apt-get install --no-install-recommends -y \
   apt-transport-https \
   build-essential \
   ca-certificates \
@@ -45,10 +45,10 @@ RUN apt-get update -y && \
   ./aws/install && \
   rm -rf aws && \
   # Add additional apt repos all at once
-  echo "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"      | tee /etc/apt/sources.list.d/docker.list           && \
+  echo "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"      | tee /etc/apt/sources.list.d/docker.list && \
   # Install second wave of dependencies
   apt-get update -y && \
-  apt-get install -y docker-ce && \
+  apt-get install --no-install-recommends -y docker-ce && \
   # Clean up the lists work
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size.

The change I made:
* I added the `--no-install-recommends` to with apt-get in order to not install unnecessary packages and reduce the image size.


Impact on the image size:
* Image size before repair: 1.47 GB
* Image size after repair: 1.36 GB
* Difference: 113.78 MB (7.55%)

I hope that you will find these changes useful to you. Let me know if you have any questions or concerns.

Thanks,