### PR TITLE
chore: increase golangci-lint timeout to 10 min

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ fmt:
 
 .PHONY: lint
 lint:
-	$(GOLANGCI_LINT) run
+	$(GOLANGCI_LINT) run --timeout=10m
 
 .PHONY: test
 test:


### PR DESCRIPTION
We have recently started to see that golangci-lint is timing out more frequently. Let's bump its timeout to 10 minutes to stop this from happening.