### PR TITLE
ability to trigger releases on dispatch with tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
     name: GoReleaser
     needs:
       - release
-    if: needs.release.outputs.new-release-published == 'true'
+    if: needs.release.outputs.new-release-published == 'true' || (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/'))
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The new workflow should enable manual release of assets to a tag when needed.