### PR TITLE
Revert "ability to trigger releases on dispatch with tags (#488)"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
     name: GoReleaser
     needs:
       - release
-    if: needs.release.outputs.new-release-published == 'true' || (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/'))
+    if: needs.release.outputs.new-release-published == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This reverts commit 1e3ce0c2b477bc755ab3219aa833e96934ea9d05.

This change is not required. Removing to avoid confusion