### PR TITLE
limit test workflow concurrency

### DIFF
--- a/.github/workflows/dashboard-test.yaml
+++ b/.github/workflows/dashboard-test.yaml
@@ -8,6 +8,10 @@ on:
       - develop
   pull_request:
 
+concurrency:
+  group: ci-dash-tests-${{ github.ref_name }}
+  cancel-in-progress: true
+
 env:
   GOPROXY: https://proxy.golang.org
 


### PR DESCRIPTION
Currently it runs on push and PR from develop, which makes the tests run twice on the same commit hash.