### PR TITLE
feat: Preview Features

### DIFF
--- a/pkg/preview/feature.go
+++ b/pkg/preview/feature.go
@@ -1,0 +1,7 @@
+package preview
+
+type Feature = string
+
+const (
+	Feature_Websockets Feature = "websockets"
+)

--- a/pkg/preview/feature.go
+++ b/pkg/preview/feature.go
@@ -1,3 +1,19 @@
+// Copyright Nitric Pty Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package preview
 
 type Feature = string

--- a/pkg/project/config.go
+++ b/pkg/project/config.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
+	"github.com/nitrictech/cli/pkg/preview"
 	"github.com/nitrictech/cli/pkg/utils"
 )
 
@@ -44,9 +45,10 @@ type HandlerConfig struct {
 // }
 
 type BaseConfig struct {
-	Name     string `yaml:"name"`
-	Dir      string `yaml:"-"`
-	Handlers []any  `yaml:"handlers"`
+	Name            string            `yaml:"name"`
+	Dir             string            `yaml:"-"`
+	Handlers        []any             `yaml:"handlers"`
+	PreviewFeatures []preview.Feature `yaml:"preview-features"`
 }
 
 type Config struct {
@@ -72,6 +74,10 @@ func configFromBaseConfig(base BaseConfig) (*Config, error) {
 	newConfig := &Config{
 		BaseConfig:       base,
 		ConcreteHandlers: make([]*HandlerConfig, 0),
+	}
+
+	if newConfig.BaseConfig.PreviewFeatures == nil {
+		newConfig.BaseConfig.PreviewFeatures = make([]string, 0)
 	}
 
 	for _, h := range base.Handlers {

--- a/pkg/project/types.go
+++ b/pkg/project/types.go
@@ -53,9 +53,10 @@ func (p *Project) IsPreviewFeatureEnabled(feat preview.Feature) bool {
 
 func New(config BaseConfig) *Project {
 	return &Project{
-		Name:      config.Name,
-		Dir:       config.Dir,
-		Functions: map[string]Function{},
+		Name:            config.Name,
+		Dir:             config.Dir,
+		Functions:       map[string]Function{},
+		PreviewFeatures: config.PreviewFeatures,
 		History: &history.History{
 			ProjectDir: config.Dir,
 		},

--- a/pkg/project/types.go
+++ b/pkg/project/types.go
@@ -17,9 +17,10 @@
 package project
 
 import (
+	"github.com/samber/lo"
+
 	"github.com/nitrictech/cli/pkg/history"
 	"github.com/nitrictech/cli/pkg/preview"
-	"github.com/samber/lo"
 )
 
 type ComputeUnit struct {

--- a/pkg/project/types.go
+++ b/pkg/project/types.go
@@ -18,6 +18,8 @@ package project
 
 import (
 	"github.com/nitrictech/cli/pkg/history"
+	"github.com/nitrictech/cli/pkg/preview"
+	"github.com/samber/lo"
 )
 
 type ComputeUnit struct {
@@ -37,10 +39,15 @@ type Function struct {
 }
 
 type Project struct {
-	Dir       string              `yaml:"-"`
-	Name      string              `yaml:"name"`
-	Functions map[string]Function `yaml:"functions,omitempty"`
-	History   *history.History    `yaml:"-"`
+	Dir             string              `yaml:"-"`
+	Name            string              `yaml:"name"`
+	Functions       map[string]Function `yaml:"functions,omitempty"`
+	PreviewFeatures []preview.Feature   `yaml:"-"`
+	History         *history.History    `yaml:"-"`
+}
+
+func (p *Project) IsPreviewFeatureEnabled(feat preview.Feature) bool {
+	return lo.Contains(p.PreviewFeatures, feat)
 }
 
 func New(config BaseConfig) *Project {


### PR DESCRIPTION
WIP Proposal for Adding Preview feature flags to the ntiric.yaml project file.

Current planned syntax is:

```yaml
preview-features:
  - websockets
```

This will take the form of a gate that will simply be in the form of an if gate:

```go
if !proj.IsPreviewFeatureEnabled(preview.Feature_Websockets) {
// feature is not enabled exit and let user know that if they want to use this feature they must enable it in their project file
}
```

Features will be centralised in a new `preview` package so their references throughout the CLI are easy to track down.

Currently this will work well when running a nitric deployment, but will also need to be able to do that same work during a nitric run. Possibly raise a warning during `nitric start` when it detects that a preview feature has been used?

Could also look at incorporating: https://openfeature.dev/ or something similiar, but for now a baked in gate for config based optin will work.

Depends on: https://github.com/nitrictech/nitric/pull/444. Being merged to implement the first flag.