### PR TITLE
feat: Custom dockerfile support

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/nitrictech/cli/pkg/containerengine"
 	"github.com/nitrictech/cli/pkg/project"
-	"github.com/nitrictech/cli/pkg/runtime"
 )
 
 func dynamicDockerfile(dir, name string) (*os.File, error) {
@@ -45,7 +44,7 @@ func buildFunction(s *project.Project, f project.Function) func() error {
 	return func() error {
 		ce, _ := containerengine.Discover()
 
-		rt, err := runtime.NewRunTimeFromHandler(fun.Handler)
+		rt, err := fun.GetRuntime()
 		if err != nil {
 			return err
 		}

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -38,8 +38,11 @@ func TestBuildBaseImages(t *testing.T) {
 
 	defer os.RemoveAll(dir)
 
-	s := project.New(project.BaseConfig{Name: "", Dir: dir})
-	s.Functions = map[string]project.Function{"foo": {Handler: "functions/list.ts", ComputeUnit: project.ComputeUnit{Name: "foo"}}}
+	s := project.New(project.BaseConfig{Name: "", Dir: dir, PreviewFeatures: []string{"dockerfile"}})
+	s.Functions = map[string]project.Function{"foo": {Project: s, Handler: "functions/list.ts", Name: "foo", Config: &project.HandlerConfig{
+		Type:  "default",
+		Match: "functions/list.ts",
+	}}}
 
 	me.EXPECT().Build(gomock.Any(), dir, "-foo", gomock.Any(), []string{
 		".nitric/", "!.nitric/*.yaml", ".git/", ".idea/", ".vscode/", ".github/", "*.dockerfile", "*.dockerignore", "node_modules/",

--- a/pkg/cmd/feedback.go
+++ b/pkg/cmd/feedback.go
@@ -25,6 +25,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/nitrictech/cli/pkg/ghissue"
+	"github.com/nitrictech/cli/pkg/utils"
 )
 
 var feedbackCmd = &cobra.Command{
@@ -43,7 +44,7 @@ var feedbackCmd = &cobra.Command{
 		d := ghissue.Gather()
 
 		diag, err := yaml.Marshal(d)
-		cobra.CheckErr(err)
+		utils.CheckErr(err)
 
 		qs := []*survey.Question{
 			{
@@ -77,7 +78,7 @@ var feedbackCmd = &cobra.Command{
 			},
 		}
 		err = survey.Ask(qs, &answers)
-		cobra.CheckErr(err)
+		utils.CheckErr(err)
 
 		pterm.Info.Println("Please create a github issue by clicking on the link below")
 		fmt.Println(ghissue.IssueLink(answers.Repo, answers.Kind, answers.Title, answers.Body))

--- a/pkg/cmd/newproject.go
+++ b/pkg/cmd/newproject.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/nitrictech/cli/pkg/project"
 	"github.com/nitrictech/cli/pkg/templates"
+	"github.com/nitrictech/cli/pkg/utils"
 )
 
 var (
@@ -65,7 +66,7 @@ nitric new hello-world "official/TypeScript - Starter" `,
 
 		downloadr := templates.NewDownloader()
 		dirs, err := downloadr.Names()
-		cobra.CheckErr(err)
+		utils.CheckErr(err)
 
 		templateNameQu.Prompt = &survey.Select{
 			Message: "Choose a template:",
@@ -115,16 +116,16 @@ nitric new hello-world "official/TypeScript - Starter" `,
 
 		if len(qs) > 0 {
 			err = survey.Ask(qs, &answers)
-			cobra.CheckErr(err)
+			utils.CheckErr(err)
 		}
 
 		cd, err := filepath.Abs(".")
-		cobra.CheckErr(err)
+		utils.CheckErr(err)
 
 		projDir := path.Join(cd, answers.ProjectName)
 
 		err = downloadr.DownloadDirectoryContents(answers.TemplateName, projDir, force)
-		cobra.CheckErr(err)
+		utils.CheckErr(err)
 
 		var p *project.Config
 		// Check if the downloaded template has a default nitric.yaml file
@@ -152,7 +153,7 @@ nitric new hello-world "official/TypeScript - Starter" `,
 			}{}
 
 			err = survey.Ask(globQ, &globA)
-			cobra.CheckErr(err)
+			utils.CheckErr(err)
 
 			p = &project.Config{
 				BaseConfig: project.BaseConfig{
@@ -164,12 +165,12 @@ nitric new hello-world "official/TypeScript - Starter" `,
 		} else {
 			// Load and update the project name in the template's nitric.yaml
 			p, err = project.ConfigFromProjectPath(projDir)
-			cobra.CheckErr(err)
+			utils.CheckErr(err)
 			p.Name = answers.ProjectName
 		}
 
 		err = p.ToFile()
-		cobra.CheckErr(err)
+		utils.CheckErr(err)
 	},
 	Args: cobra.MaximumNArgs(2),
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -67,7 +67,7 @@ var rootCmd = &cobra.Command{
 		if _, err := os.Stat(utils.NitricHomeDir()); os.IsNotExist(err) {
 			err := os.MkdirAll(utils.NitricHomeDir(), 0o700) // Create the Nitric Home Directory if it's missing
 			if err != nil {
-				cobra.CheckErr(fmt.Errorf("Failed to create nitric home directory. %w", err))
+				utils.CheckErr(fmt.Errorf("Failed to create nitric home directory. %w", err))
 			}
 		}
 	},
@@ -83,7 +83,7 @@ func Execute() {
 		}
 	}()
 
-	cobra.CheckErr(rootCmd.Execute())
+	utils.CheckErr(rootCmd.Execute())
 }
 
 func init() {
@@ -94,7 +94,7 @@ func init() {
 	err := rootCmd.RegisterFlagCompletionFunc("output", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return output.OutputTypeFlag.Allowed, cobra.ShellCompDirectiveDefault
 	})
-	cobra.CheckErr(err)
+	utils.CheckErr(err)
 
 	newProjectCmd.Flags().BoolVarP(&force, "force", "f", false, "force project creation, even in non-empty directories.")
 	rootCmd.AddCommand(newProjectCmd)
@@ -113,7 +113,7 @@ func init() {
 
 func addAlias(from, to string, commonCommand bool) {
 	cmd, _, err := rootCmd.Find(strings.Split(from, " "))
-	cobra.CheckErr(err)
+	utils.CheckErr(err)
 
 	if cmd.Annotations == nil {
 		cmd.Annotations = map[string]string{}
@@ -131,7 +131,7 @@ func addAlias(from, to string, commonCommand bool) {
 			newArgs = append(newArgs, strings.Split(from, " ")...)
 			newArgs = append(newArgs, args...)
 			os.Args = newArgs
-			cobra.CheckErr(rootCmd.Execute())
+			utils.CheckErr(rootCmd.Execute())
 		},
 		DisableFlagParsing: true, // the real command will parse the flags
 	}

--- a/pkg/cmd/run/root.go
+++ b/pkg/cmd/run/root.go
@@ -58,21 +58,21 @@ var runCmd = &cobra.Command{
 		log.SetFlags(0)
 
 		config, err := project.ConfigFromProjectPath("")
-		cobra.CheckErr(err)
+		utils.CheckErr(err)
 
 		proj, err := project.FromConfig(config)
-		cobra.CheckErr(err)
+		utils.CheckErr(err)
 
 		envFiles := utils.FilesExisting(".env", ".env.development", envFile)
 		envMap := map[string]string{}
 		if len(envFiles) > 0 {
 			envMap, err = godotenv.Read(envFiles...)
-			cobra.CheckErr(err)
+			utils.CheckErr(err)
 		}
 
 		dash, err := dashboard.New(proj, envMap)
 		if err != nil {
-			cobra.CheckErr(err)
+			utils.CheckErr(err)
 		}
 
 		ls := run.NewLocalServices(proj, false, dash)
@@ -82,10 +82,10 @@ var runCmd = &cobra.Command{
 		}
 
 		ce, err := containerengine.Discover()
-		cobra.CheckErr(err)
+		utils.CheckErr(err)
 
 		logger := ce.Logger(proj.Dir)
-		cobra.CheckErr(logger.Start())
+		utils.CheckErr(logger.Start())
 
 		createBaseImage := tasklet.Runner{
 			StartMsg: "Building Images",
@@ -156,7 +156,7 @@ var runCmd = &cobra.Command{
 
 		err = ls.Refresh()
 		if err != nil {
-			cobra.CheckErr(err)
+			utils.CheckErr(err)
 		}
 
 		stackState.Update(pool, ls)
@@ -197,7 +197,7 @@ var runCmd = &cobra.Command{
 		_ = area.Stop()
 		_ = logger.Stop()
 		// Stop the membrane
-		cobra.CheckErr(ls.Stop())
+		utils.CheckErr(ls.Stop())
 	},
 	Args: cobra.ExactArgs(0),
 }

--- a/pkg/cmd/start/root.go
+++ b/pkg/cmd/start/root.go
@@ -35,6 +35,7 @@ import (
 	"github.com/nitrictech/cli/pkg/project"
 	"github.com/nitrictech/cli/pkg/run"
 	"github.com/nitrictech/cli/pkg/tasklet"
+	"github.com/nitrictech/cli/pkg/utils"
 )
 
 var startCmd = &cobra.Command{
@@ -52,15 +53,13 @@ var startCmd = &cobra.Command{
 		log.SetFlags(0)
 
 		config, err := project.ConfigFromProjectPath("")
-		cobra.CheckErr(err)
+		utils.CheckErr(err)
 
 		proj, err := project.FromConfig(config)
-		cobra.CheckErr(err)
+		utils.CheckErr(err)
 
 		dash, err := dashboard.New(proj, map[string]string{})
-		if err != nil {
-			cobra.CheckErr(err)
-		}
+		utils.CheckErr(err)
 
 		ls := run.NewLocalServices(&project.Project{
 			Name: "local",
@@ -137,7 +136,7 @@ var startCmd = &cobra.Command{
 
 		_ = area.Stop()
 		// Stop the membrane
-		cobra.CheckErr(ls.Stop())
+		utils.CheckErr(ls.Stop())
 	},
 	Args: cobra.ExactArgs(0),
 }

--- a/pkg/codeconfig/function.go
+++ b/pkg/codeconfig/function.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/nitrictech/cli/pkg/project"
 	"github.com/nitrictech/cli/pkg/utils"
 	v1 "github.com/nitrictech/nitric/core/pkg/api/nitric/v1"
 )
@@ -111,6 +112,7 @@ func (a *Api) AddSecurity(name string, scopes []string) {
 // FunctionDependencies - Stores information about a Nitric Function, and it's dependencies
 type FunctionDependencies struct {
 	name                string
+	functionConfig      project.Function
 	apis                map[string]*Api
 	subscriptions       map[string]*v1.SubscriptionWorker
 	schedules           map[string]*v1.ScheduleWorker
@@ -267,9 +269,10 @@ func (a *FunctionDependencies) AddSecret(name string, s *v1.SecretResource) {
 }
 
 // NewFunction - creates a new Nitric Function, ready to register handlers and dependencies.
-func NewFunction(name string) *FunctionDependencies {
+func NewFunction(name string, projectFunction project.Function) *FunctionDependencies {
 	return &FunctionDependencies{
 		name:                name,
+		functionConfig:      projectFunction,
 		apis:                make(map[string]*Api),
 		subscriptions:       make(map[string]*v1.SubscriptionWorker),
 		schedules:           make(map[string]*v1.ScheduleWorker),

--- a/pkg/codeconfig/uprequest.go
+++ b/pkg/codeconfig/uprequest.go
@@ -285,7 +285,7 @@ func (c *codeConfig) ToUpRequest() (*deploy.DeployUpRequest, error) {
 						},
 					},
 					Workers: int32(f.WorkerCount()),
-					Type:    fun.Type,
+					Type:    fun.Config.Type,
 					Env:     c.envMap,
 				},
 			},

--- a/pkg/command/dependency.go
+++ b/pkg/command/dependency.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/spf13/cobra"
+
+	"github.com/nitrictech/cli/pkg/utils"
 )
 
 type Dependency struct {
@@ -88,7 +90,7 @@ var Docker = &Dependency{
 func AddDependencyCheck(cmd *cobra.Command, deps ...*Dependency) *cobra.Command {
 	cmd.PreRun = func(cmd *cobra.Command, args []string) {
 		err := checkDependencies(deps...)
-		cobra.CheckErr(err)
+		utils.CheckErr(err)
 	}
 
 	return cmd

--- a/pkg/preview/feature.go
+++ b/pkg/preview/feature.go
@@ -1,0 +1,23 @@
+// Copyright Nitric Pty Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preview
+
+type Feature = string
+
+const (
+	Feature_Websockets Feature = "websockets"
+)

--- a/pkg/preview/feature.go
+++ b/pkg/preview/feature.go
@@ -19,5 +19,6 @@ package preview
 type Feature = string
 
 const (
+	Feature_Dockerfile Feature = "dockerfile"
 	Feature_Websockets Feature = "websockets"
 )

--- a/pkg/project/config.go
+++ b/pkg/project/config.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
+	"github.com/nitrictech/cli/pkg/preview"
 	"github.com/nitrictech/cli/pkg/utils"
 )
 
@@ -44,9 +45,10 @@ type HandlerConfig struct {
 // }
 
 type BaseConfig struct {
-	Name     string `yaml:"name"`
-	Dir      string `yaml:"-"`
-	Handlers []any  `yaml:"handlers"`
+	Name            string            `yaml:"name"`
+	Dir             string            `yaml:"-"`
+	Handlers        []any             `yaml:"handlers"`
+	PreviewFeatures []preview.Feature `yaml:"preview-features"`
 }
 
 type Config struct {
@@ -72,6 +74,10 @@ func configFromBaseConfig(base BaseConfig) (*Config, error) {
 	newConfig := &Config{
 		BaseConfig:       base,
 		ConcreteHandlers: make([]*HandlerConfig, 0),
+	}
+
+	if newConfig.BaseConfig.PreviewFeatures == nil {
+		newConfig.BaseConfig.PreviewFeatures = make([]string, 0)
 	}
 
 	for _, h := range base.Handlers {

--- a/pkg/project/types.go
+++ b/pkg/project/types.go
@@ -17,7 +17,10 @@
 package project
 
 import (
+	"github.com/samber/lo"
+
 	"github.com/nitrictech/cli/pkg/history"
+	"github.com/nitrictech/cli/pkg/preview"
 )
 
 type ComputeUnit struct {
@@ -37,17 +40,23 @@ type Function struct {
 }
 
 type Project struct {
-	Dir       string              `yaml:"-"`
-	Name      string              `yaml:"name"`
-	Functions map[string]Function `yaml:"functions,omitempty"`
-	History   *history.History    `yaml:"-"`
+	Dir             string              `yaml:"-"`
+	Name            string              `yaml:"name"`
+	Functions       map[string]Function `yaml:"functions,omitempty"`
+	PreviewFeatures []preview.Feature   `yaml:"-"`
+	History         *history.History    `yaml:"-"`
+}
+
+func (p *Project) IsPreviewFeatureEnabled(feat preview.Feature) bool {
+	return lo.Contains(p.PreviewFeatures, feat)
 }
 
 func New(config BaseConfig) *Project {
 	return &Project{
-		Name:      config.Name,
-		Dir:       config.Dir,
-		Functions: map[string]Function{},
+		Name:            config.Name,
+		Dir:             config.Dir,
+		Functions:       map[string]Function{},
+		PreviewFeatures: config.PreviewFeatures,
 		History: &history.History{
 			ProjectDir: config.Dir,
 		},

--- a/pkg/run/function.go
+++ b/pkg/run/function.go
@@ -93,18 +93,14 @@ type FunctionOpts struct {
 	ProjectName     string
 	Handler         string
 	RunCtx          string
+	Runtime         runtime.Runtime
 	ContainerEngine containerengine.ContainerEngine
 }
 
 func newFunction(opts FunctionOpts) (*Function, error) {
-	rt, err := runtime.NewRunTimeFromHandler(opts.Handler)
-	if err != nil {
-		return nil, err
-	}
-
 	return &Function{
 		name:        opts.Name,
-		rt:          rt,
+		rt:          opts.Runtime,
 		projectName: opts.ProjectName,
 		handler:     opts.Handler,
 		runCtx:      opts.RunCtx,
@@ -126,8 +122,14 @@ func FunctionsFromHandlers(p *project.Project) ([]*Function, error) {
 			return nil, err
 		}
 
+		runtime, err := f.GetRuntime()
+		if err != nil {
+			return nil, err
+		}
+
 		if f, err := newFunction(FunctionOpts{
 			Name:            f.Name,
+			Runtime:         runtime,
 			RunCtx:          p.Dir,
 			Handler:         relativeHandlerPath,
 			ContainerEngine: ce,

--- a/pkg/run/pool.go
+++ b/pkg/run/pool.go
@@ -19,8 +19,7 @@ package run
 import (
 	"strconv"
 
-	"github.com/spf13/cobra"
-
+	cliutils "github.com/nitrictech/cli/pkg/utils"
 	"github.com/nitrictech/nitric/core/pkg/utils"
 	"github.com/nitrictech/nitric/core/pkg/worker"
 	"github.com/nitrictech/nitric/core/pkg/worker/pool"
@@ -85,7 +84,7 @@ func (r *RunProcessPool) Listen(l WorkerListener) {
 
 func NewRunProcessPool() *RunProcessPool {
 	maxWorkers, err := strconv.Atoi(utils.GetEnv("MAX_WORKERS", "300"))
-	cobra.CheckErr(err)
+	cliutils.CheckErr(err)
 
 	return &RunProcessPool{
 		listeners: make([]WorkerListener, 0),

--- a/pkg/runtime/custom.go
+++ b/pkg/runtime/custom.go
@@ -1,0 +1,74 @@
+// Copyright Nitric Pty Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	_ "embed"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type custom struct {
+	handler    string
+	dockerfile string
+	args       map[string]string
+}
+
+var _ Runtime = &custom{}
+
+func (t *custom) ContainerName() string {
+	return strings.Replace(filepath.Base(t.handler), filepath.Ext(t.handler), "", 1)
+}
+
+func (t *custom) BuildIgnore(additional ...string) []string {
+	// make an ignore file from one if there is one available
+	dockerfile, err := os.ReadFile(fmt.Sprintf("%s.dockerignore", t.dockerfile))
+	ignoreContents := []string{}
+	if err == nil {
+		ignoreContents = strings.Split(string(dockerfile), "\n")
+	}
+
+	ignoreContents = append(ignoreContents, commonIgnore...)
+
+	return append(additional, ignoreContents...)
+}
+
+func (t *custom) BuildArgs() map[string]string {
+	args := map[string]string{
+		"HANDLER": filepath.ToSlash(t.handler),
+	}
+
+	for k, v := range t.args {
+		args[k] = v
+	}
+
+	return args
+}
+
+func (t *custom) BaseDockerFile(w io.Writer) error {
+	dockerfile, err := os.ReadFile(t.dockerfile)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(dockerfile)
+
+	return err
+}

--- a/pkg/runtime/custom.go
+++ b/pkg/runtime/custom.go
@@ -38,9 +38,9 @@ func (t *custom) ContainerName() string {
 }
 
 func (t *custom) BuildIgnore(additional ...string) []string {
+	ignoreContents := []string{}
 	// make an ignore file from one if there is one available
 	dockerfile, err := os.ReadFile(fmt.Sprintf("%s.dockerignore", t.dockerfile))
-	ignoreContents := []string{}
 	if err == nil {
 		ignoreContents = strings.Split(string(dockerfile), "\n")
 	}

--- a/pkg/runtime/types.go
+++ b/pkg/runtime/types.go
@@ -45,6 +45,14 @@ const (
 
 var commonIgnore = []string{".nitric/", "!.nitric/*.yaml", ".git/", ".idea/", ".vscode/", ".github/", "*.dockerfile", "*.dockerignore"}
 
+func NewCustomRuntime(handler string, dockerfile string, args map[string]string) (Runtime, error) {
+	return &custom{
+		handler:    handler,
+		dockerfile: dockerfile,
+		args:       args,
+	}, nil
+}
+
 func NewRunTimeFromHandler(handler string) (Runtime, error) {
 	rt := RuntimeExt(strings.Replace(filepath.Ext(handler), ".", "", -1))
 

--- a/pkg/utils/errors.go
+++ b/pkg/utils/errors.go
@@ -18,7 +18,17 @@ package utils
 
 import (
 	"fmt"
+	"os"
+
+	"github.com/pterm/pterm"
 )
+
+func CheckErr(err error) {
+	if err != nil {
+		pterm.Error.Println(err)
+		os.Exit(1)
+	}
+}
 
 func NewIncompatibleWorkerError() error {
 	return fmt.Errorf("unable to register incompatible worker. This can be caused by out of date Nitric CLI versions, an upgrade may resolve this issue")


### PR DESCRIPTION
Add ability to override default runtime dockerfile with own implementation. This differs from custom container support, as it still uses glob matching to produce one image per matched handler file/entrypoint.

This will allow better support for custom builds and supporting dependencies that require additional scripts to be run as part of their install processes e.g. prisma.

Example config:

```yaml
name: ts-hello
handlers:
  - match: functions/*.ts
    type: default
    docker:
      # All functions in the functions directory will be build using this dockerfile
      file: ./docker/node.dockerfile
      args: {}
preview-features:
   - dockerfile # Enable preview feature
```