### PR TITLE
feat: Allow separate src and destination caches for docker build caching

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -41,6 +41,7 @@ func dynamicDockerfile(dir, name string) (*os.File, error) {
 
 func buildFunction(s *project.Project, f project.Function) func() error {
 	fun := &f
+
 	return func() error {
 		ce, _ := containerengine.Discover()
 

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -17,12 +17,17 @@
 package build
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/pterm/pterm"
 	"github.com/samber/lo"
+	"golang.org/x/sync/errgroup"
+
+	goruntime "runtime"
 
 	"github.com/nitrictech/cli/pkg/containerengine"
 	"github.com/nitrictech/cli/pkg/project"
@@ -34,15 +39,11 @@ func dynamicDockerfile(dir, name string) (*os.File, error) {
 	return os.Create(filepath.Join(dir, fmt.Sprintf("%s.nitric.dynamic.dockerfile", name)))
 }
 
-// Build base non-nitric wrapped docker image
-// These will also be used for config as code runs
-func BuildBaseImages(s *project.Project) error {
-	ce, err := containerengine.Discover()
-	if err != nil {
-		return err
-	}
+func buildFunction(s *project.Project, f project.Function) func() error {
+	fun := &f
+	return func() error {
+		ce, _ := containerengine.Discover()
 
-	for _, fun := range s.Functions {
 		rt, err := runtime.NewRunTimeFromHandler(fun.Handler)
 		if err != nil {
 			return err
@@ -62,8 +63,6 @@ func BuildBaseImages(s *project.Project) error {
 			return err
 		}
 
-		pterm.Debug.Println("Building image for" + f.Name())
-
 		ingoreFunctions := lo.Filter(lo.Values(s.Functions), func(item project.Function, index int) bool {
 			return item.Name != fun.Name
 		})
@@ -72,10 +71,41 @@ func BuildBaseImages(s *project.Project) error {
 			return item.Handler
 		})
 
-		if err := ce.Build(filepath.Base(f.Name()), s.Dir, fmt.Sprintf("%s-%s", s.Name, fun.Name), rt.BuildArgs(), rt.BuildIgnore(ignoreHandlers...)); err != nil {
+		ignores := rt.BuildIgnore(ignoreHandlers...)
+
+		if err := ce.Build(filepath.Base(f.Name()), s.Dir, fmt.Sprintf("%s-%s", s.Name, fun.Name), rt.BuildArgs(), ignores); err != nil {
 			return err
 		}
+
+		return nil
+	}
+}
+
+// Build base non-nitric wrapped docker image
+// These will also be used for config as code runs
+func BuildBaseImages(s *project.Project) error {
+	errs, _ := errgroup.WithContext(context.Background())
+	// set concurrent build limit here
+
+	maxConcurrency := lo.Min([]int{goruntime.GOMAXPROCS(0), goruntime.NumCPU()})
+
+	maxConcurrencyEnv := os.Getenv("MAX_BUILD_CONCURRENCY")
+	if maxConcurrencyEnv != "" {
+		newVal, err := strconv.Atoi(maxConcurrencyEnv)
+		if err != nil {
+			return fmt.Errorf("invalid value for MAX_BUILD_CONCURRENCY must be int got %s", maxConcurrencyEnv)
+		}
+
+		maxConcurrency = newVal
 	}
 
-	return nil
+	pterm.Debug.Printfln("running builds %d at a time", maxConcurrency)
+
+	errs.SetLimit(maxConcurrency)
+
+	for _, fun := range s.Functions {
+		errs.Go(buildFunction(s, fun))
+	}
+
+	return errs.Wait()
 }

--- a/pkg/containerengine/docker.go
+++ b/pkg/containerengine/docker.go
@@ -90,7 +90,9 @@ var builderLock = sync.Mutex{}
 func (d *docker) createBuider() error {
 	builderLock.Lock()
 	defer builderLock.Unlock() // Create a known fixed nitric builder to allow caching
+
 	cmd := exec.Command("docker", "buildx", "create", "--name", "nitric", "--bootstrap", "--driver=docker-container", "--node", "nitric0")
+
 	return cmd.Run()
 }
 

--- a/pkg/containerengine/docker.go
+++ b/pkg/containerengine/docker.go
@@ -27,6 +27,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 
@@ -83,10 +84,13 @@ func (d *docker) Inspect(imageName string) (types.ImageInspect, error) {
 	return ii, err
 }
 
+var builderLock = sync.Mutex{}
+
 // Create a known nitric container builder to allow custom cache configuration
 func (d *docker) createBuider() error {
-	// Create a known fixed nitric builder to allow caching
-	cmd := exec.Command("docker", "buildx", "create", "--name", "nitric", "--driver=docker-container", "--node", "nitric0")
+	builderLock.Lock()
+	defer builderLock.Unlock() // Create a known fixed nitric builder to allow caching
+	cmd := exec.Command("docker", "buildx", "create", "--name", "nitric", "--bootstrap", "--driver=docker-container", "--node", "nitric0")
 	return cmd.Run()
 }
 

--- a/pkg/containerengine/docker.go
+++ b/pkg/containerengine/docker.go
@@ -125,14 +125,37 @@ func (d *docker) Build(dockerfile, srcPath, imageTag string, buildArgs map[strin
 	}
 	args = append(args, buildArgsCmd...)
 
+	cacheTo := ""
+	cacheFrom := ""
+
 	dockerBuildCache := os.Getenv("DOCKER_BUILD_CACHE")
 	if dockerBuildCache != "" {
 		imageCache := filepath.Join(dockerBuildCache, imageTag)
 
-		cacheTo := fmt.Sprintf("--cache-to=type=local,dest=%s", imageCache)
-		cacheFrom := fmt.Sprintf("--cache-from=type=local,src=%s", imageCache)
+		cacheTo = fmt.Sprintf("--cache-to=type=local,dest=%s", imageCache)
+		cacheFrom = fmt.Sprintf("--cache-from=type=local,src=%s", imageCache)
+	}
 
-		args = append(args, cacheTo, cacheFrom)
+	dockerBuildCacheDest := os.Getenv("DOCKER_BUILD_CACHE_DEST")
+	if dockerBuildCacheDest != "" {
+		imageCache := filepath.Join(dockerBuildCacheDest, imageTag)
+
+		cacheTo = fmt.Sprintf("--cache-to=type=local,dest=%s", imageCache)
+	}
+
+	dockerBuildCacheSrc := os.Getenv("DOCKER_BUILD_CACHE_SRC")
+	if dockerBuildCacheSrc != "" {
+		imageCache := filepath.Join(dockerBuildCacheSrc, imageTag)
+
+		cacheFrom = fmt.Sprintf("--cache-from=type=local,src=%s", imageCache)
+	}
+
+	if cacheTo != "" {
+		args = append(args, cacheTo)
+	}
+
+	if cacheFrom != "" {
+		args = append(args, cacheFrom)
 	}
 
 	cmd := exec.Command("docker", args...)

--- a/pkg/runtime/csharp.go
+++ b/pkg/runtime/csharp.go
@@ -38,7 +38,7 @@ func (t *csharp) ContainerName() string {
 }
 
 func (t *csharp) BuildIgnore(additional ...string) []string {
-	baseIgnores := append(commonIgnore, additional...)
+	baseIgnores := append(additional, commonIgnore...)
 	return append(baseIgnores, "obj/", "bin/")
 }
 

--- a/pkg/runtime/generate_test.go
+++ b/pkg/runtime/generate_test.go
@@ -18,167 +18,42 @@ package runtime
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
 
 func TestGenerate(t *testing.T) {
+	tsFile, _ := os.ReadFile("typescript.dockerfile")
+	goFile, _ := os.ReadFile("golang.dockerfile")
+	pythonFile, _ := os.ReadFile("python.dockerfile")
+	jsFile, _ := os.ReadFile("javascript.dockerfile")
+
 	tests := []struct {
 		name        string
 		handler     string
 		wantFwriter string
 	}{
 		{
-			name:    "ts",
-			handler: "functions/list.ts",
-			wantFwriter: `# syntax=docker/dockerfile:1
-FROM node:alpine as build
-
-ARG HANDLER
-
-# Python and make are required by certain native package build processes in NPM packages.
-RUN apk add g++ make py3-pip
-
-RUN yarn global add typescript @vercel/ncc
-
-WORKDIR /usr/app
-
-COPY package.json *.lock *-lock.json /
-
-RUN yarn import || echo ""
-
-RUN set -ex && \
-    yarn install --production --frozen-lockfile --cache-folder /tmp/.cache && \
-    rm -rf /tmp/.cache
-
-RUN test -f tsconfig.json || echo "{\"compilerOptions\":{\"esModuleInterop\":true,\"target\":\"es2015\",\"moduleResolution\":\"node\"}}" > tsconfig.json
-
-COPY . .
-
-# make prisma external to bundle - https://github.com/prisma/prisma/issues/16901#issuecomment-1362940774 \
-# TODO: remove when custom dockerfile support is available
-RUN \
-  --mount=type=cache,target=/tmp/ncc-cache \
-  ncc build ${HANDLER} -o lib/ -e .prisma/client -e @prisma/client -t
-
-FROM node:alpine as final
-
-WORKDIR /usr/app
-
-RUN apk update && \
-    apk add --no-cache ca-certificates && \
-    update-ca-certificates
-
-COPY package.json *.lock *-lock.json ./
-
-RUN set -ex && \
-    yarn install --production --frozen-lockfile --cache-folder /tmp/.cache && \
-    rm -rf /tmp/.cache
-
-COPY . .
-
-COPY --from=build /usr/app/lib/ ./lib/
-
-# prisma fix for docker installs: https://github.com/prisma/docs/issues/4365
-# TODO: remove when custom dockerfile support is available
-RUN test -d ./prisma && npx prisma generate || echo "";
-
-ENTRYPOINT ["node", "lib/index.js"]`,
+			name:        "ts",
+			handler:     "functions/list.ts",
+			wantFwriter: string(tsFile),
 		},
 		{
-			name:    "go",
-			handler: "pkg/handler/list.go",
-			wantFwriter: `FROM golang:alpine as build
-
-ARG HANDLER
-
-WORKDIR /app/
-
-COPY go.mod *.sum ./
-
-RUN go mod download
-
-COPY . .
-
-RUN go build -o /bin/main ./${HANDLER}/...
-
-FROM alpine
-
-COPY --from=build /bin/main /bin/main
-
-RUN chmod +x-rw /bin/main
-RUN apk update && \
-    apk add --no-cache tzdata ca-certificates && \
-    update-ca-certificates
-
-ENTRYPOINT ["/bin/main"]`,
+			name:        "go",
+			handler:     "pkg/handler/list.go",
+			wantFwriter: string(goFile),
 		},
 		{
-			name:    "python",
-			handler: "list.py",
-			wantFwriter: `FROM python:3.11-slim
-
-ARG HANDLER
-
-ENV HANDLER=${HANDLER}
-ENV PYTHONUNBUFFERED=TRUE
-
-RUN apt-get update -y && \
-    apt-get install -y ca-certificates && \
-    update-ca-certificates
-
-RUN pip install --upgrade pip pipenv
-
-# Copy either requirements.txt for Pipfile
-COPY requirements.tx[t] Pipfil[e] Pipfile.loc[k] ./
-
-# Guarantee lock file if we have a Pipfile and no Pipfile.lock
-RUN (stat Pipfile && pipenv lock) || echo "No Pipfile found"
-
-# Output a requirements.txt file for final module install if there is a Pipfile.lock found
-RUN (stat Pipfile.lock && pipenv requirements > requirements.txt) || echo "No Pipfile.lock found"
-
-RUN pip install --no-cache-dir -r requirements.txt
-
-COPY . .
-
-ENTRYPOINT python $HANDLER
-`,
+			name:        "python",
+			handler:     "list.py",
+			wantFwriter: string(pythonFile),
 		},
 		{
-			name:    "js",
-			handler: "functions/list.js",
-			wantFwriter: `# syntax=docker/dockerfile:1
-FROM node:alpine
-
-ARG HANDLER
-ENV HANDLER=${HANDLER}
-
-RUN apk update && \
-    apk add --no-cache ca-certificates && \
-    update-ca-certificates
-
-# Python and make are required by certain native package build processes in NPM packages.
-ENV PYTHONUNBUFFERED=1
-RUN apk add --update --no-cache python3 make g++ && ln -sf python3 /usr/bin/python
-RUN python3 -m ensurepip
-RUN pip3 install --no-cache --upgrade pip setuptools
-
-COPY . .
-
-RUN yarn import || echo Lockfile already exists
-
-RUN \
-  set -ex; \
-  yarn install --production --frozen-lockfile --cache-folder /tmp/.cache; \
-  rm -rf /tmp/.cache; \
-  # prisma fix for docker installs: https://github.com/prisma/docs/issues/4365
-  # TODO: remove when custom dockerfile support is available
-  test -d ./prisma && npx prisma generate || echo "";
-
-ENTRYPOINT node $HANDLER
-`,
+			name:        "js",
+			handler:     "functions/list.js",
+			wantFwriter: string(jsFile),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/runtime/golang.go
+++ b/pkg/runtime/golang.go
@@ -33,7 +33,7 @@ var _ Runtime = &golang{}
 var golangDockerfile string
 
 func (t *golang) BuildIgnore(additional ...string) []string {
-	return append(commonIgnore, additional...)
+	return append(additional, commonIgnore...)
 }
 
 func (t *golang) BaseDockerFile(w io.Writer) error {

--- a/pkg/runtime/javascript.go
+++ b/pkg/runtime/javascript.go
@@ -41,7 +41,7 @@ func (t *javascript) ContainerName() string {
 }
 
 func (t *javascript) BuildIgnore(additional ...string) []string {
-	return append(javascriptIgnoreList, additional...)
+	return append(additional, javascriptIgnoreList...)
 }
 
 func (t *javascript) BaseDockerFile(w io.Writer) error {

--- a/pkg/runtime/python.go
+++ b/pkg/runtime/python.go
@@ -38,7 +38,7 @@ func (t *python) ContainerName() string {
 }
 
 func (t *python) BuildIgnore(additional ...string) []string {
-	baseIgnores := append(commonIgnore, additional...)
+	baseIgnores := append(additional, commonIgnore...)
 	return append(baseIgnores, "__pycache__/", "*.py[cod]", "*$py.class")
 }
 

--- a/pkg/runtime/typescript.go
+++ b/pkg/runtime/typescript.go
@@ -38,7 +38,7 @@ func (t *typescript) ContainerName() string {
 }
 
 func (t *typescript) BuildIgnore(additional ...string) []string {
-	return append(javascriptIgnoreList, additional...)
+	return append(additional, javascriptIgnoreList...)
 }
 
 func (t *typescript) BuildArgs() map[string]string {


### PR DESCRIPTION
Reusing the same cache can cause the cache to grow indefinitely.

By allowing the read and write cache to be separate outputs will be cleaner and result in a more relevant cache result.