### PR TITLE
chore: normalize file names for docker

### DIFF
--- a/pkg/runtime/csharp.go
+++ b/pkg/runtime/csharp.go
@@ -34,7 +34,7 @@ type csharp struct {
 var _ Runtime = &csharp{}
 
 func (t *csharp) ContainerName() string {
-	return strings.ToLower(strings.Replace(filepath.Base(t.handler), filepath.Ext(t.handler), "", 1))
+	return normalizeFileName(t.handler)
 }
 
 func (t *csharp) BuildIgnore(additional ...string) []string {

--- a/pkg/runtime/javascript.go
+++ b/pkg/runtime/javascript.go
@@ -20,7 +20,6 @@ import (
 	_ "embed"
 	"io"
 	"path/filepath"
-	"strings"
 )
 
 type javascript struct {
@@ -37,7 +36,7 @@ var (
 )
 
 func (t *javascript) ContainerName() string {
-	return strings.Replace(filepath.Base(t.handler), filepath.Ext(t.handler), "", 1)
+	return normalizeFileName(t.handler)
 }
 
 func (t *javascript) BuildIgnore(additional ...string) []string {

--- a/pkg/runtime/python.go
+++ b/pkg/runtime/python.go
@@ -20,7 +20,6 @@ import (
 	_ "embed"
 	"io"
 	"path/filepath"
-	"strings"
 )
 
 //go:embed python.dockerfile
@@ -34,7 +33,7 @@ type python struct {
 var _ Runtime = &python{}
 
 func (t *python) ContainerName() string {
-	return strings.Replace(filepath.Base(t.handler), filepath.Ext(t.handler), "", 1)
+	return normalizeFileName(t.handler)
 }
 
 func (t *python) BuildIgnore(additional ...string) []string {

--- a/pkg/runtime/types.go
+++ b/pkg/runtime/types.go
@@ -53,6 +53,13 @@ func NewCustomRuntime(handler string, dockerfile string, args map[string]string)
 	}, nil
 }
 
+// normalizeFileName - Normalizes a file name to a usable container name
+func normalizeFileName(handler string) string {
+	baseName := strings.Replace(filepath.Base(handler), filepath.Ext(handler), "", 1)
+	// replace all instances of . with -
+	return strings.Replace(baseName, ".", "-", -1)
+}
+
 func NewRunTimeFromHandler(handler string) (Runtime, error) {
 	rt := RuntimeExt(strings.Replace(filepath.Ext(handler), ".", "", -1))
 

--- a/pkg/runtime/types.go
+++ b/pkg/runtime/types.go
@@ -56,7 +56,6 @@ func NewCustomRuntime(handler string, dockerfile string, args map[string]string)
 // normalizeFileName - Normalizes a file name to a usable container name
 func normalizeFileName(handler string) string {
 	baseName := strings.Replace(filepath.Base(handler), filepath.Ext(handler), "", 1)
-	// replace all instances of . with -
 	return strings.Replace(baseName, ".", "-", -1)
 }
 

--- a/pkg/runtime/types_test.go
+++ b/pkg/runtime/types_test.go
@@ -1,0 +1,25 @@
+package runtime
+
+import (
+	"testing"
+)
+
+func TestNormalizeExtension(t *testing.T) {
+	handler := "test.ts"
+
+	result := normalizeFileName(handler)
+
+	if result != "test" {
+		t.Error("expected ", result, "to equal test")
+	}
+}
+
+func TestNormalizeWithDots(t *testing.T) {
+	handler := "test.api.ts"
+
+	result := normalizeFileName(handler)
+
+	if result != "test-api" {
+		t.Error("expected ", result, "to equal test-api")
+	}
+}

--- a/pkg/runtime/types_test.go
+++ b/pkg/runtime/types_test.go
@@ -1,3 +1,19 @@
+// Copyright Nitric Pty Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package runtime
 
 import (

--- a/pkg/runtime/typescript.go
+++ b/pkg/runtime/typescript.go
@@ -20,7 +20,6 @@ import (
 	_ "embed"
 	"io"
 	"path/filepath"
-	"strings"
 )
 
 type typescript struct {
@@ -34,7 +33,7 @@ var _ Runtime = &typescript{}
 var typescriptDockerfile string
 
 func (t *typescript) ContainerName() string {
-	return strings.Replace(filepath.Base(t.handler), filepath.Ext(t.handler), "", 1)
+	return normalizeFileName(t.handler)
 }
 
 func (t *typescript) BuildIgnore(additional ...string) []string {


### PR DESCRIPTION
Normalize file names for docker (replaces '.' with '-' after extension removal on a file name) for example processing.job.ts => processing-job, or public.api.ts => public-api. 