### PR TITLE
maintain state for websockets in dash

### DIFF
--- a/dashboard/cypress/e2e/websockets.cy.ts
+++ b/dashboard/cypress/e2e/websockets.cy.ts
@@ -6,9 +6,9 @@ describe("Websockets Spec", () => {
 
   it("should retrieve correct websockets", () => {
     cy.get("h2").should("contain.text", "socket");
-    cy.getTestEl("Topics-count").should("have.text", "2");
+    cy.getTestEl("Websockets-count").should("have.text", "3");
 
-    const expectedWebsockets = ["socket", "socket-2"];
+    const expectedWebsockets = ["socket", "socket-2", "socket-3"];
 
     expectedWebsockets.forEach((id) => {
       cy.get(`[data-rct-item-id="${id}"]`).should("exist");
@@ -69,6 +69,26 @@ describe("Websockets Spec", () => {
     cy.getTestEl("clear-messages-btn", 5000).click();
 
     cy.getTestEl("accordion-message-0").should("not.exist");
+  });
+
+  it("should handle errors in the connect callback", () => {
+    cy.get(`[data-rct-item-id="socket-3"]`).click();
+
+    cy.getTestEl("send-messages-tab-trigger", 5000).click();
+
+    cy.getTestEl("connect-btn").click();
+
+    cy.getTestEl("connected-status").should("have.text", "Disconnected");
+
+    cy.getTestEl("accordion-message-0").should(
+      "have.text",
+      "Disconnected from ws://localhost:4005"
+    );
+
+    cy.getTestEl("accordion-message-1").should(
+      "have.text",
+      "Error connecting to ws://localhost:4005, check your connect callback"
+    );
   });
 
   it("should handle query params", () => {

--- a/dashboard/src/components/websockets/WSExplorer.tsx
+++ b/dashboard/src/components/websockets/WSExplorer.tsx
@@ -201,7 +201,7 @@ const WSExplorer = () => {
       socket.addEventListener("error", (event: any) => {
         setMessages((prev) => [
           {
-            data: event.error,
+            data: `Error connecting to ${websocketAddress}, check your connect callback`,
             ts: new Date().getTime(),
             type: "error",
           },

--- a/dashboard/test-app/functions/my-test-function.ts
+++ b/dashboard/test-app/functions/my-test-function.ts
@@ -16,6 +16,8 @@ const socket = websocket("socket");
 
 const socket2 = websocket("socket-2");
 
+const socket3 = websocket("socket-3");
+
 const connections = collection("connections").for(
   "reading",
   "writing",
@@ -332,4 +334,16 @@ const broadcast = async (data: string | Uint8Array) => {
 socket.on("message", async (ctx) => {
   // broadcast message to all clients (including the sender)
   await broadcast(ctx.req.data);
+});
+
+socket3.on("connect", (ctx) => {
+  ctx.res.success = false;
+});
+
+socket3.on("disconnect", (ctx) => {
+  ctx.res.success = false;
+});
+
+socket3.on("message", (ctx) => {
+  ctx.res.success = false;
 });


### PR DESCRIPTION
This ensure that switching between websockets in the local dashboard does the following:
- maintains the state values for fields, including messages
- disconnects the previous websocket