### PR TITLE
feat: JVM runtime Support

### DIFF
--- a/pkg/runtime/generate_test.go
+++ b/pkg/runtime/generate_test.go
@@ -29,6 +29,7 @@ func TestGenerate(t *testing.T) {
 	goFile, _ := os.ReadFile("golang.dockerfile")
 	pythonFile, _ := os.ReadFile("python.dockerfile")
 	jsFile, _ := os.ReadFile("javascript.dockerfile")
+	jvmFile, _ := os.ReadFile("jvm.dockerfile")
 
 	tests := []struct {
 		name        string
@@ -54,6 +55,11 @@ func TestGenerate(t *testing.T) {
 			name:        "js",
 			handler:     "functions/list.js",
 			wantFwriter: string(jsFile),
+		},
+		{
+			name:        "jar",
+			handler:     "outout/fat.jar",
+			wantFwriter: string(jvmFile),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/runtime/jvm.dockerfile
+++ b/pkg/runtime/jvm.dockerfile
@@ -1,0 +1,9 @@
+# syntax=docker/dockerfile:1
+FROM openjdk:22-slim
+
+ARG HANDLER
+
+COPY $HANDLER /usr/app/app.jar
+
+CMD ["java", "-jar", "/usr/app/app.jar"]
+

--- a/pkg/runtime/jvm.go
+++ b/pkg/runtime/jvm.go
@@ -1,0 +1,53 @@
+// Copyright Nitric Pty Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	_ "embed"
+	"io"
+	"path/filepath"
+)
+
+//go:embed jvm.dockerfile
+var jvmDockerfile string
+
+type jvm struct {
+	rte     RuntimeExt
+	handler string
+}
+
+var _ Runtime = &jvm{}
+
+func (t *jvm) ContainerName() string {
+	return normalizeFileName(t.handler)
+}
+
+func (t *jvm) BuildIgnore(additional ...string) []string {
+	baseIgnores := append(additional, commonIgnore...)
+	return append(baseIgnores, "obj/", "bin/")
+}
+
+func (t *jvm) BaseDockerFile(w io.Writer) error {
+	_, err := w.Write([]byte(jvmDockerfile))
+	return err
+}
+
+func (t *jvm) BuildArgs() map[string]string {
+	return map[string]string{
+		"HANDLER": filepath.ToSlash(t.handler),
+	}
+}

--- a/pkg/runtime/types.go
+++ b/pkg/runtime/types.go
@@ -39,6 +39,7 @@ const (
 	RuntimePython     RuntimeExt = "py"
 	RuntimeGolang     RuntimeExt = "go"
 	RuntimeCsharp     RuntimeExt = "cs"
+	RuntimeJvm        RuntimeExt = "jar"
 
 	RuntimeUnknown RuntimeExt = ""
 )
@@ -77,6 +78,8 @@ func NewRunTimeFromHandler(handler string) (Runtime, error) {
 		return &typescript{rte: rt, handler: handler}, nil
 	case RuntimeCsharp:
 		return &csharp{rte: rt, handler: handler}, nil
+	case RuntimeJvm:
+		return &jvm{rte: rt, handler: handler}, nil
 	default:
 		return nil, errors.New("runtime '" + string(rt) + "' not supported")
 	}


### PR DESCRIPTION
A bit different from our other runtime support. Currently expects that the outputs will be compiled before running `nitric up`.

So a workflow for this would be something like `maven build && nitric up`.

With the nitric handlers referencing executable `jar` files that are output by the project.