### PR TITLE
feat: auto open local dashboard on nitric start

### DIFF
--- a/pkg/cmd/run/root.go
+++ b/pkg/cmd/run/root.go
@@ -70,7 +70,7 @@ var runCmd = &cobra.Command{
 			utils.CheckErr(err)
 		}
 
-		dash, err := dashboard.New(proj, envMap)
+		dash, err := dashboard.New(proj, envMap, true)
 		if err != nil {
 			utils.CheckErr(err)
 		}

--- a/pkg/cmd/start/root.go
+++ b/pkg/cmd/start/root.go
@@ -60,7 +60,7 @@ var startCmd = &cobra.Command{
 		proj, err := project.FromConfig(config)
 		utils.CheckErr(err)
 
-		dash, err := dashboard.New(proj, map[string]string{}, noBrowser)
+		dash, err := dashboard.New(proj, map[string]string{}, noBrowser || output.CI)
 		utils.CheckErr(err)
 
 		ls := run.NewLocalServices(&project.Project{
@@ -148,7 +148,7 @@ var startCmd = &cobra.Command{
 }
 
 func RootCommand() *cobra.Command {
-	startCmd.PersistentFlags().BoolVar(&noBrowser, "no-browser", false, "disable browser opening for local dashboard")
+	startCmd.PersistentFlags().BoolVar(&noBrowser, "no-browser", false, "disable browser opening for local dashboard, note: in CI mode the browser opening feature is disabled")
 
 	return startCmd
 }

--- a/pkg/cmd/start/root.go
+++ b/pkg/cmd/start/root.go
@@ -38,6 +38,8 @@ import (
 	"github.com/nitrictech/cli/pkg/utils"
 )
 
+var noBrowser bool
+
 var startCmd = &cobra.Command{
 	Use:         "start",
 	Short:       "Run nitric services locally for development and testing",
@@ -58,7 +60,7 @@ var startCmd = &cobra.Command{
 		proj, err := project.FromConfig(config)
 		utils.CheckErr(err)
 
-		dash, err := dashboard.New(proj, map[string]string{})
+		dash, err := dashboard.New(proj, map[string]string{}, noBrowser)
 		utils.CheckErr(err)
 
 		ls := run.NewLocalServices(&project.Project{
@@ -146,5 +148,7 @@ var startCmd = &cobra.Command{
 }
 
 func RootCommand() *cobra.Command {
+	startCmd.PersistentFlags().BoolVar(&noBrowser, "no-browser", false, "disable browser opening for local dashboard")
+
 	return startCmd
 }


### PR DESCRIPTION
On start command, opens browser on localhost:port. Added --no-browser flag to start command to avoid this happening.

Tested on Windows. Please test on linux and macos