### PR TITLE
fix: ensure websocket port is correct when not on default port

### DIFF
--- a/dashboard/src/lib/utils/get-host.ts
+++ b/dashboard/src/lib/utils/get-host.ts
@@ -1,9 +1,9 @@
+const isDev = import.meta.env.DEV;
+
 export const getHost = () => {
   if (typeof window === "undefined") {
     return null;
   }
 
-  return window && window.location.host.startsWith("localhost")
-    ? "localhost:49152"
-    : window.location.host;
+  return isDev ? "localhost:49152" : window.location.host;
 };


### PR DESCRIPTION
anyone who doesn't get the default port 49152 needs this