### PR TITLE
fix: ensure encoded path params work in dash

### DIFF
--- a/dashboard/src/components/apis/APIExplorer.tsx
+++ b/dashboard/src/components/apis/APIExplorer.tsx
@@ -23,6 +23,7 @@ import {
   fieldRowArrToHeaders,
   getHost,
   generateResponse,
+  isValidUrl,
 } from "../../lib/utils";
 import APIResponseContent from "./APIResponseContent";
 import CodeEditor from "./CodeEditor";
@@ -265,6 +266,21 @@ const APIExplorer = () => {
         setCallLoading(false);
         toast.error(
           `Required path parameter(s) missing: ${emptyParams
+            .map((p) => p.key)
+            .join(", ")}`
+        );
+
+        return;
+      }
+
+      const invalidValues = request.pathParams.filter(
+        (param) => !isValidUrl(param.value)
+      );
+
+      if (invalidValues.length) {
+        setCallLoading(false);
+        toast.error(
+          `Invalid path parameter value for: ${invalidValues
             .map((p) => p.key)
             .join(", ")}`
         );

--- a/dashboard/src/lib/utils/generate-path.ts
+++ b/dashboard/src/lib/utils/generate-path.ts
@@ -6,7 +6,7 @@ export function generatePath(
   queryParams: FieldRow[]
 ) {
   pathParams.forEach((p) => {
-    path = path.replace(`{${p.key}}`, encodeURIComponent(p.value));
+    path = path.replace(`{${p.key}}`, p.value);
   });
 
   if (queryParams.length) {

--- a/dashboard/src/lib/utils/index.ts
+++ b/dashboard/src/lib/utils/index.ts
@@ -11,3 +11,4 @@ export * from "./get-host";
 export * from "./generate-response";
 export * from "./strings";
 export * from "./cn";
+export * from "./is-valid-url";

--- a/dashboard/src/lib/utils/is-valid-url.ts
+++ b/dashboard/src/lib/utils/is-valid-url.ts
@@ -1,0 +1,7 @@
+export const isValidUrl = (value: string) => {
+  try {
+    return !decodeURI(value).includes("%");
+  } catch (e) {
+    return false;
+  }
+};

--- a/pkg/dashboard/handlers.go
+++ b/pkg/dashboard/handlers.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/nitrictech/cli/pkg/history"
@@ -133,15 +134,15 @@ func (d *Dashboard) handleCallProxy() func(http.ResponseWriter, *http.Request) {
 		path := strings.TrimPrefix(r.URL.Path, "/api/call/")
 
 		// Build proxy request URL with query parameters
-		query := r.URL.RawQuery
-		if query != "" {
-			query = "?" + query
+		targetURL := &url.URL{
+			Scheme:   "http",
+			Host:     callAddress,
+			Path:     path,
+			RawQuery: r.URL.RawQuery,
 		}
 
-		url := fmt.Sprintf("http://%s/%s%s", callAddress, path, query)
-
 		// Create a new request object
-		req, err := http.NewRequest(r.Method, url, r.Body)
+		req, err := http.NewRequest(r.Method, targetURL.String(), r.Body)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/pkg/run/gateway.go
+++ b/pkg/run/gateway.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -240,12 +241,20 @@ func (s *BaseHttpGateway) handleApiHttpRequest(idx int) fasthttp.RequestHandler 
 			query[k].Value = append(query[k].Value, string(val))
 		})
 
+		path := string(ctx.URI().Path())
+
+		_, err := url.Parse(path)
+		if err != nil {
+			ctx.Error(fmt.Sprintf("Bad Request: %v", err), 400)
+			return
+		}
+
 		httpTrigger := &v1.TriggerRequest{
 			Data: ctx.Request.Body(),
 			Context: &v1.TriggerRequest_Http{
 				Http: &v1.HttpTriggerContext{
 					Method:      string(ctx.Request.Header.Method()),
-					Path:        string(ctx.URI().PathOriginal()),
+					Path:        path,
 					Headers:     headers,
 					QueryParams: query,
 				},


### PR DESCRIPTION
This change allows for decoded path params and detects invalid paths such as % as per a live cloud deployment