### PR TITLE
add more info to conflicting resources error.

### DIFF
--- a/pkg/codeconfig/codeconfig.go
+++ b/pkg/codeconfig/codeconfig.go
@@ -376,7 +376,7 @@ func (c *codeConfig) apiSpec(api string, workers []*apiHandler) (*openapi3.T, er
 				// If the operation already exists we should fail
 				// NOTE: This should not happen as operations are stored in a map
 				// in the api state for functions
-				return nil, fmt.Errorf("found conflicting operations")
+				return nil, fmt.Errorf("found conflicting operations, you may already have a running instance of your project")
 			}
 
 			exts := map[string]interface{}{

--- a/pkg/codeconfig/codeconfig.go
+++ b/pkg/codeconfig/codeconfig.go
@@ -371,11 +371,9 @@ func (c *codeConfig) apiSpec(api string, workers []*apiHandler) (*openapi3.T, er
 		}
 
 		for _, m := range w.worker.Methods {
-			// TODO FIX
+			// conflicting operations typically arise from 'nitric start'
+			//  when the same/similar projects are run at the same time.
 			if pathItem.Operations() != nil && pathItem.Operations()[m] != nil {
-				// If the operation already exists we should fail
-				// NOTE: This should not happen as operations are stored in a map
-				// in the api state for functions
 				return nil, fmt.Errorf("found conflicting operations, you may already have a running instance of your project")
 			}
 


### PR DESCRIPTION
When trying to run the same project twice, intentionally or accidently, the error message provided is somewhat unclear.