### PR TITLE
stack down command

### DIFF
--- a/pkgplus/view/tui/commands/stack/down/stack_down.go
+++ b/pkgplus/view/tui/commands/stack/down/stack_down.go
@@ -88,8 +88,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				})
 
 				if !found {
-					m.errs = append(m.errs, fmt.Errorf("received update for resource [%s], without associated nitric parent resource", content.Update.SubResource))
-					return m, tea.Quit
+					nitricResource = &stack.Resource{
+						Name:     fmt.Sprintf("%s::%s", content.Update.Id.Type.String(), content.Update.Id.Name),
+						Message:  "",
+						Action:   content.Update.Action,
+						Status:   content.Update.Status,
+						Children: make([]*stack.Resource, 0),
+					}
+
+					// Add it from the given parent details
+					m.stack.Children = append(m.stack.Children, nitricResource)
 				}
 
 				parent = nitricResource

--- a/pkgplus/view/tui/commands/stack/down/stack_down.go
+++ b/pkgplus/view/tui/commands/stack/down/stack_down.go
@@ -1,4 +1,4 @@
-package stack_up
+package stack_down
 
 import (
 	"fmt"
@@ -20,7 +20,7 @@ import (
 
 type Model struct {
 	stack              *stack.Resource
-	updatesChan        <-chan *deploymentspb.DeploymentUpEvent
+	updatesChan        <-chan *deploymentspb.DeploymentDownEvent
 	errorChan          <-chan error
 	providerStdoutChan <-chan string
 	providerStdout     []string
@@ -175,7 +175,7 @@ func (m Model) View() string {
 	treeView := view.New()
 
 	treeView.AddRow(
-		view.NewFragment("Nitric Up"+m.spinner.View()).WithStyle(lipgloss.NewStyle().Foreground(tui.Colors.Purple).Bold(true)),
+		view.NewFragment("Nitric Down"+m.spinner.View()).WithStyle(lipgloss.NewStyle().Foreground(tui.Colors.Purple).Bold(true)),
 		view.Break(),
 	)
 
@@ -237,7 +237,7 @@ func (m Model) View() string {
 	return treeView.Render()
 }
 
-func New(updatesChan <-chan *deploymentspb.DeploymentUpEvent, providerStdoutChan <-chan string, errorChan <-chan error) Model {
+func New(updatesChan <-chan *deploymentspb.DeploymentDownEvent, providerStdoutChan <-chan string, errorChan <-chan error) Model {
 	return Model{
 		resourcesTable: table.New(
 			table.WithColumns([]table.Column{

--- a/pkgplus/view/tui/commands/stack/down/stack_down.go
+++ b/pkgplus/view/tui/commands/stack/down/stack_down.go
@@ -62,7 +62,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.providerStdout = append(m.providerStdout, msg.Value)
 
 		return m, reactive.AwaitChannel(msg.Source)
-	case reactive.ChanMsg[*deploymentspb.DeploymentUpEvent]:
+	case reactive.ChanMsg[*deploymentspb.DeploymentDownEvent]:
 
 		// the source channel is close
 		if !msg.Ok {
@@ -70,7 +70,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		switch content := msg.Value.Content.(type) {
-		case *deploymentspb.DeploymentUpEvent_Update:
+		case *deploymentspb.DeploymentDownEvent_Update:
 
 			if content.Update == nil || content.Update.Id == nil {
 				break

--- a/pkgplus/view/tui/commands/stack/down/stack_down.go
+++ b/pkgplus/view/tui/commands/stack/down/stack_down.go
@@ -135,39 +135,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
-var verbMap = map[deploymentspb.ResourceDeploymentAction]map[deploymentspb.ResourceDeploymentStatus]string{
-	deploymentspb.ResourceDeploymentAction_CREATE: {
-		deploymentspb.ResourceDeploymentStatus_PENDING:     "create",
-		deploymentspb.ResourceDeploymentStatus_IN_PROGRESS: "creating",
-		deploymentspb.ResourceDeploymentStatus_FAILED:      "creation failed",
-		deploymentspb.ResourceDeploymentStatus_SUCCESS:     "created",
-	},
-	deploymentspb.ResourceDeploymentAction_DELETE: {
-		deploymentspb.ResourceDeploymentStatus_PENDING:     "delete",
-		deploymentspb.ResourceDeploymentStatus_SUCCESS:     "deleted",
-		deploymentspb.ResourceDeploymentStatus_IN_PROGRESS: "deleting",
-		deploymentspb.ResourceDeploymentStatus_FAILED:      "failed to delete",
-	},
-	deploymentspb.ResourceDeploymentAction_REPLACE: {
-		deploymentspb.ResourceDeploymentStatus_PENDING:     "replace",
-		deploymentspb.ResourceDeploymentStatus_SUCCESS:     "replaced",
-		deploymentspb.ResourceDeploymentStatus_IN_PROGRESS: "replacing",
-		deploymentspb.ResourceDeploymentStatus_FAILED:      "failed to replace",
-	},
-	deploymentspb.ResourceDeploymentAction_UPDATE: {
-		deploymentspb.ResourceDeploymentStatus_PENDING:     "update",
-		deploymentspb.ResourceDeploymentStatus_SUCCESS:     "updated",
-		deploymentspb.ResourceDeploymentStatus_IN_PROGRESS: "updating",
-		deploymentspb.ResourceDeploymentStatus_FAILED:      "failed to update",
-	},
-	deploymentspb.ResourceDeploymentAction_SAME: {
-		deploymentspb.ResourceDeploymentStatus_PENDING:     "unchanged",
-		deploymentspb.ResourceDeploymentStatus_SUCCESS:     "unchanged",
-		deploymentspb.ResourceDeploymentStatus_IN_PROGRESS: "unchanged",
-		deploymentspb.ResourceDeploymentStatus_FAILED:      "unchanged",
-	},
-}
-
 const maxOutputLines = 5
 
 func (m Model) View() string {
@@ -195,7 +162,7 @@ func (m Model) View() string {
 
 			rows = append(rows, table.Row{
 				lipgloss.NewStyle().MarginLeft(1).Foreground(tui.Colors.Blue).Render(linkChar) + lipgloss.NewStyle().Foreground(tui.Colors.Gray).Render(grandchild.Name),
-				verbMap[grandchild.Action][grandchild.Status] + fmt.Sprintf(" (%s)", resourceTime.Round(time.Second)),
+				stack.VerbMap[grandchild.Action][grandchild.Status] + fmt.Sprintf(" (%s)", resourceTime.Round(time.Second)),
 			})
 		}
 	}

--- a/pkgplus/view/tui/commands/stack/resource.go
+++ b/pkgplus/view/tui/commands/stack/resource.go
@@ -15,3 +15,36 @@ type Resource struct {
 	FinishTime time.Time
 	Children   []*Resource
 }
+
+var VerbMap = map[deploymentspb.ResourceDeploymentAction]map[deploymentspb.ResourceDeploymentStatus]string{
+	deploymentspb.ResourceDeploymentAction_CREATE: {
+		deploymentspb.ResourceDeploymentStatus_PENDING:     "create",
+		deploymentspb.ResourceDeploymentStatus_IN_PROGRESS: "creating",
+		deploymentspb.ResourceDeploymentStatus_FAILED:      "creation failed",
+		deploymentspb.ResourceDeploymentStatus_SUCCESS:     "created",
+	},
+	deploymentspb.ResourceDeploymentAction_DELETE: {
+		deploymentspb.ResourceDeploymentStatus_PENDING:     "delete",
+		deploymentspb.ResourceDeploymentStatus_SUCCESS:     "deleted",
+		deploymentspb.ResourceDeploymentStatus_IN_PROGRESS: "deleting",
+		deploymentspb.ResourceDeploymentStatus_FAILED:      "failed to delete",
+	},
+	deploymentspb.ResourceDeploymentAction_REPLACE: {
+		deploymentspb.ResourceDeploymentStatus_PENDING:     "replace",
+		deploymentspb.ResourceDeploymentStatus_SUCCESS:     "replaced",
+		deploymentspb.ResourceDeploymentStatus_IN_PROGRESS: "replacing",
+		deploymentspb.ResourceDeploymentStatus_FAILED:      "failed to replace",
+	},
+	deploymentspb.ResourceDeploymentAction_UPDATE: {
+		deploymentspb.ResourceDeploymentStatus_PENDING:     "update",
+		deploymentspb.ResourceDeploymentStatus_SUCCESS:     "updated",
+		deploymentspb.ResourceDeploymentStatus_IN_PROGRESS: "updating",
+		deploymentspb.ResourceDeploymentStatus_FAILED:      "failed to update",
+	},
+	deploymentspb.ResourceDeploymentAction_SAME: {
+		deploymentspb.ResourceDeploymentStatus_PENDING:     "unchanged",
+		deploymentspb.ResourceDeploymentStatus_SUCCESS:     "unchanged",
+		deploymentspb.ResourceDeploymentStatus_IN_PROGRESS: "unchanged",
+		deploymentspb.ResourceDeploymentStatus_FAILED:      "unchanged",
+	},
+}

--- a/pkgplus/view/tui/commands/stack/resource.go
+++ b/pkgplus/view/tui/commands/stack/resource.go
@@ -1,0 +1,17 @@
+package stack
+
+import (
+	"time"
+
+	deploymentspb "github.com/nitrictech/nitric/core/pkg/proto/deployments/v1"
+)
+
+type Resource struct {
+	Name       string
+	Message    string
+	Action     deploymentspb.ResourceDeploymentAction
+	Status     deploymentspb.ResourceDeploymentStatus
+	StartTime  time.Time
+	FinishTime time.Time
+	Children   []*Resource
+}

--- a/pkgplus/view/tui/commands/stack/up/stack_up.go
+++ b/pkgplus/view/tui/commands/stack/up/stack_up.go
@@ -135,39 +135,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
-var verbMap = map[deploymentspb.ResourceDeploymentAction]map[deploymentspb.ResourceDeploymentStatus]string{
-	deploymentspb.ResourceDeploymentAction_CREATE: {
-		deploymentspb.ResourceDeploymentStatus_PENDING:     "create",
-		deploymentspb.ResourceDeploymentStatus_IN_PROGRESS: "creating",
-		deploymentspb.ResourceDeploymentStatus_FAILED:      "creation failed",
-		deploymentspb.ResourceDeploymentStatus_SUCCESS:     "created",
-	},
-	deploymentspb.ResourceDeploymentAction_DELETE: {
-		deploymentspb.ResourceDeploymentStatus_PENDING:     "delete",
-		deploymentspb.ResourceDeploymentStatus_SUCCESS:     "deleted",
-		deploymentspb.ResourceDeploymentStatus_IN_PROGRESS: "deleting",
-		deploymentspb.ResourceDeploymentStatus_FAILED:      "failed to delete",
-	},
-	deploymentspb.ResourceDeploymentAction_REPLACE: {
-		deploymentspb.ResourceDeploymentStatus_PENDING:     "replace",
-		deploymentspb.ResourceDeploymentStatus_SUCCESS:     "replaced",
-		deploymentspb.ResourceDeploymentStatus_IN_PROGRESS: "replacing",
-		deploymentspb.ResourceDeploymentStatus_FAILED:      "failed to replace",
-	},
-	deploymentspb.ResourceDeploymentAction_UPDATE: {
-		deploymentspb.ResourceDeploymentStatus_PENDING:     "update",
-		deploymentspb.ResourceDeploymentStatus_SUCCESS:     "updated",
-		deploymentspb.ResourceDeploymentStatus_IN_PROGRESS: "updating",
-		deploymentspb.ResourceDeploymentStatus_FAILED:      "failed to update",
-	},
-	deploymentspb.ResourceDeploymentAction_SAME: {
-		deploymentspb.ResourceDeploymentStatus_PENDING:     "unchanged",
-		deploymentspb.ResourceDeploymentStatus_SUCCESS:     "unchanged",
-		deploymentspb.ResourceDeploymentStatus_IN_PROGRESS: "unchanged",
-		deploymentspb.ResourceDeploymentStatus_FAILED:      "unchanged",
-	},
-}
-
 const maxOutputLines = 5
 
 func (m Model) View() string {
@@ -195,7 +162,7 @@ func (m Model) View() string {
 
 			rows = append(rows, table.Row{
 				lipgloss.NewStyle().MarginLeft(1).Foreground(tui.Colors.Blue).Render(linkChar) + lipgloss.NewStyle().Foreground(tui.Colors.Gray).Render(grandchild.Name),
-				verbMap[grandchild.Action][grandchild.Status] + fmt.Sprintf(" (%s)", resourceTime.Round(time.Second)),
+				stack.VerbMap[grandchild.Action][grandchild.Status] + fmt.Sprintf(" (%s)", resourceTime.Round(time.Second)),
 			})
 		}
 	}


### PR DESCRIPTION
wire up stack down to event loop, still needs updates to the provider to make sure that nitric resource parents are tied in correctly with child resources (as they're declared backwards for a tear down operation).