### PR TITLE
chore: update go version for tests

### DIFF
--- a/.github/workflows/aws-e2e.yaml
+++ b/.github/workflows/aws-e2e.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.21
 
       - name: Build Nitric
         run: |
@@ -76,7 +76,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.21
 
       - name: Build Nitric
         run: |

--- a/.github/workflows/cli-test.yaml
+++ b/.github/workflows/cli-test.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.21
       - name: Download go modules
         run: go mod download
       - name: Run Lint
@@ -67,6 +67,6 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.21
       - name: Build
         run: make build

--- a/.github/workflows/local-run.yaml
+++ b/.github/workflows/local-run.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.21
 
       - name: Build Nitric
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.21
 
       - uses: goreleaser/goreleaser-action@v3
         with:


### PR DESCRIPTION
Go version 1.21 required to use built-in max and min functions.
