### PR TITLE
Add Dockerfile template for Dart projects

### DIFF
--- a/pkg/project/runtime/dart.dockerfile
+++ b/pkg/project/runtime/dart.dockerfile
@@ -1,0 +1,22 @@
+FROM dart:stable AS build
+
+ARG HANDLER
+WORKDIR /app
+
+# Resolve app dependencies.
+COPY pubspec.* ./
+RUN dart pub get
+
+# Copy app source code and AOT compile it.
+COPY . .
+# Ensure packages are still up-to-date if anything has changed
+RUN dart pub get --offline
+RUN dart compile exe ./${HANDLER} -o bin/main
+
+# Build a minimal serving image from AOT-compiled `/server` and required system
+# libraries and configuration files stored in `/runtime/` from the build stage.
+FROM scratch
+COPY --from=build /runtime/ /
+COPY --from=build /app/bin/main /app/bin/
+
+ENTRYPOINT ["/app/bin/main"]


### PR DESCRIPTION
This pull request adds a Dockerfile template for Dart projects. 


### Notes

Tested the Dockerfile locally, and I was able to at least get to the point where the protocol buffer contract was failing.