### PR TITLE
fix: ensure docker runtimes support dockerignore, empty build args and ignore other entrypoint files

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -309,6 +309,10 @@ func fromProjectConfiguration(projectConfig *ProjectConfiguration, fs afero.Fs) 
 
 			var buildContext *runtime.RuntimeBuildContext
 
+			otherEntryPointFiles := lo.Filter(files, func(file string, index int) bool {
+				return file != f
+			})
+
 			if serviceSpec.Runtime != "" {
 				// We have a custom runtime
 				customRuntime, ok := projectConfig.Runtimes[serviceSpec.Runtime]
@@ -320,8 +324,7 @@ func fromProjectConfiguration(projectConfig *ProjectConfiguration, fs afero.Fs) 
 					relativeServiceEntrypointPath,
 					customRuntime.Dockerfile,
 					customRuntime.Args,
-					// TODO: Get other entrypoint files as ignores
-					[]string{},
+					otherEntryPointFiles,
 					fs,
 				)
 				if err != nil {
@@ -332,8 +335,7 @@ func fromProjectConfiguration(projectConfig *ProjectConfiguration, fs afero.Fs) 
 					relativeServiceEntrypointPath,
 					"",
 					map[string]string{},
-					// TODO: Get other entrypoint files as ignores
-					[]string{},
+					otherEntryPointFiles,
 					fs,
 				)
 				if err != nil {

--- a/pkg/project/runtime/generate_test.go
+++ b/pkg/project/runtime/generate_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/spf13/afero"
 )
 
 func TestGenerate(t *testing.T) {
@@ -29,6 +30,8 @@ func TestGenerate(t *testing.T) {
 	pythonFile, _ := os.ReadFile("python.dockerfile")
 	jsFile, _ := os.ReadFile("javascript.dockerfile")
 	jvmFile, _ := os.ReadFile("jvm.dockerfile")
+
+	fs := afero.NewOsFs()
 
 	tests := []struct {
 		name        string
@@ -63,7 +66,7 @@ func TestGenerate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rt, err := NewBuildContext(tt.handler, "", map[string]string{}, []string{}, nil)
+			rt, err := NewBuildContext(tt.handler, "", map[string]string{}, []string{}, fs)
 			if err != nil {
 				t.Error(err)
 			}

--- a/pkg/project/runtime/runtime.go
+++ b/pkg/project/runtime/runtime.go
@@ -70,7 +70,7 @@ func getDockerIgnores(dockerIgnorePath string, fs afero.Fs) ([]string, error) {
 		return lines, nil
 	}
 
-	return nil, nil
+	return []string{}, nil
 }
 
 func customBuildContext(entrypointFilePath string, dockerfilePath string, buildArgs map[string]string, additionalIgnores []string, fs afero.Fs) (*RuntimeBuildContext, error) {

--- a/pkg/project/runtime/runtime.go
+++ b/pkg/project/runtime/runtime.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/samber/lo"
 	"github.com/spf13/afero"
 )
 
@@ -47,6 +48,31 @@ const (
 
 var commonIgnore = []string{".nitric/", "!.nitric/*.yaml", ".git/", ".idea/", ".vscode/", ".github/", "*.dockerfile", "*.dockerignore"}
 
+func getDockerIgnores(dockerIgnorePath string, fs afero.Fs) ([]string, error) {
+	// Check if the file exists
+	exists, err := afero.Exists(fs, dockerIgnorePath)
+	if err != nil {
+		return nil, err
+	}
+
+	if exists {
+		// Read the file
+		content, err := afero.ReadFile(fs, dockerIgnorePath)
+		if err != nil {
+			return nil, err
+		}
+
+		// Split the content into lines
+		lines := lo.Filter[string](strings.Split(string(content), "\n"), func(line string, index int) bool {
+			return strings.TrimSpace(line) != ""
+		})
+
+		return lines, nil
+	}
+
+	return nil, nil
+}
+
 func customBuildContext(entrypointFilePath string, dockerfilePath string, buildArgs map[string]string, additionalIgnores []string, fs afero.Fs) (*RuntimeBuildContext, error) {
 	// Get the dockerfile contents
 	// dockerfilePath
@@ -54,8 +80,6 @@ func customBuildContext(entrypointFilePath string, dockerfilePath string, buildA
 	if err != nil {
 		return nil, err
 	}
-
-	// Get the ignore file contents
 
 	// ensure build args exists
 	if buildArgs == nil {
@@ -181,10 +205,26 @@ func dartBuildContext(entrypointFilePath string, additionalIgnores []string) (*R
 // if a dockerfile path is provided a custom runtime is assumed, otherwise the entrypoint file is used for automatic detection of language runtime.
 func NewBuildContext(entrypointFilePath string, dockerfilePath string, buildArgs map[string]string, additionalIgnores []string, fs afero.Fs) (*RuntimeBuildContext, error) {
 	if dockerfilePath != "" {
+		dockerIgnorePath := fmt.Sprintf("%s.dockerignore", dockerfilePath)
+
+		dockerIgnores, err := getDockerIgnores(dockerIgnorePath, fs)
+		if err != nil {
+			return nil, err
+		}
+
+		additionalIgnores = append(additionalIgnores, dockerIgnores...)
+
 		return customBuildContext(entrypointFilePath, dockerfilePath, buildArgs, additionalIgnores, fs)
 	}
 
 	ext := filepath.Ext(entrypointFilePath)
+
+	dockerIgnores, err := getDockerIgnores(".dockerignore", fs)
+	if err != nil {
+		return nil, err
+	}
+
+	additionalIgnores = append(additionalIgnores, dockerIgnores...)
 
 	switch ext {
 	case ".cs":

--- a/pkg/project/runtime/runtime.go
+++ b/pkg/project/runtime/runtime.go
@@ -57,6 +57,11 @@ func customBuildContext(entrypointFilePath string, dockerfilePath string, buildA
 
 	// Get the ignore file contents
 
+	// ensure build args exists
+	if buildArgs == nil {
+		buildArgs = map[string]string{}
+	}
+
 	// Append handler to build args
 	buildArgs["HANDLER"] = filepath.ToSlash(entrypointFilePath)
 


### PR DESCRIPTION
- Stops the CLI from breaking when no args are defined
- Allows .dockerignore to be used for default runtimes
- Allows a custom runtime to define a dockerignore by "[dockerfile]".dockerignore
- Adds other entrypoint files to dockerignore