### PR TITLE
fix: ensure cli templates are always updated

### DIFF
--- a/pkg/project/templates/contents.go
+++ b/pkg/project/templates/contents.go
@@ -155,7 +155,9 @@ func (d *downloader) repository() error {
 
 		// provide the getter needed to download the files
 		Getters: map[string]getter.Getter{
-			"https": &getter.HttpGetter{},
+			"https": &getter.HttpGetter{
+				DoNotCheckHeadFirst: true,
+			},
 		},
 	})
 


### PR DESCRIPTION
To test check `.nitric/store/cli-templates.yaml` modified time:

- Does not change on current CLI
- Does change with this build