### PR TITLE
fix: add content-disposition

### DIFF
--- a/pkg/cloud/storage/storage.go
+++ b/pkg/cloud/storage/storage.go
@@ -494,6 +494,7 @@ func NewLocalStorageService(opts StorageOptions) (*LocalStorageService, error) {
 		}
 
 		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Disposition", "attachment; filename="+filepath.Base(req.Key))
 		w.WriteHeader(http.StatusOK)
 
 		_, err = w.Write(resp.Body)


### PR DESCRIPTION
Allows downloads using the signed download URL to set an appropriate name on the downloaded file.
