### PR TITLE
fix: Add service start message for running services.

### DIFF
--- a/pkg/project/service.go
+++ b/pkg/project/service.go
@@ -264,6 +264,13 @@ func (s *Service) Run(stop <-chan bool, updates chan<- ServiceRunUpdate, env map
 		err := cmd.Start()
 		if err != nil {
 			errChan <- err
+		} else {
+			updates <- ServiceRunUpdate{
+				ServiceName: s.Name,
+				Filepath:    s.filepath,
+				Status:      ServiceRunStatus_Running,
+				Message:     "started",
+			}
 		}
 
 		err = cmd.Wait()

--- a/pkg/project/service.go
+++ b/pkg/project/service.go
@@ -85,7 +85,7 @@ const (
 
 type ServiceRunUpdate struct {
 	ServiceName string
-	Filepath    string
+	Label       string
 	Message     string
 	Status      ServiceRunStatus
 	Err         error
@@ -94,7 +94,7 @@ type ServiceRunUpdate struct {
 type ServiceRunUpdateWriter struct {
 	updates     chan<- ServiceRunUpdate
 	serviceName string
-	filepath    string
+	label       string
 	status      ServiceRunStatus
 }
 
@@ -105,7 +105,7 @@ func (s *ServiceRunUpdateWriter) Write(data []byte) (int, error) {
 		ServiceName: s.serviceName,
 		Message:     msg,
 		Status:      s.status,
-		Filepath:    s.filepath,
+		Label:       s.label,
 	}
 
 	return len(data), nil
@@ -247,14 +247,14 @@ func (s *Service) Run(stop <-chan bool, updates chan<- ServiceRunUpdate, env map
 	cmd.Stdout = &ServiceRunUpdateWriter{
 		updates:     updates,
 		serviceName: s.Name,
-		filepath:    s.filepath,
+		label:       s.filepath,
 		status:      ServiceRunStatus_Running,
 	}
 
 	cmd.Stderr = &ServiceRunUpdateWriter{
 		updates:     updates,
 		serviceName: s.Name,
-		filepath:    s.filepath,
+		label:       s.filepath,
 		status:      ServiceRunStatus_Error,
 	}
 
@@ -267,9 +267,9 @@ func (s *Service) Run(stop <-chan bool, updates chan<- ServiceRunUpdate, env map
 		} else {
 			updates <- ServiceRunUpdate{
 				ServiceName: s.Name,
-				Filepath:    s.filepath,
+				Label:       "nitric",
 				Status:      ServiceRunStatus_Running,
-				Message:     "started",
+				Message:     fmt.Sprintf("started service %s", s.filepath),
 			}
 		}
 

--- a/pkg/view/tui/commands/services/run.go
+++ b/pkg/view/tui/commands/services/run.go
@@ -171,7 +171,7 @@ func (m Model) View() string {
 			statusColor = tui.Colors.Red
 		}
 
-		rv.Add("%s: ", update.Filepath).WithStyle(lipgloss.NewStyle().Foreground(svcColors[update.ServiceName]))
+		rv.Add("%s: ", update.Label).WithStyle(lipgloss.NewStyle().Foreground(svcColors[update.ServiceName]))
 
 		// we'll inject our own newline, so remove the duplicate suffix. Retain any other newlines intended by the user
 		rv.Add(strings.TrimSuffix(update.Message, "\n")).WithStyle(lipgloss.NewStyle().Foreground(statusColor))


### PR DESCRIPTION
If there are no output from the running process on stdout as part of nitric start than the user will see a "No services" messages as part of the CLI output despite the line directly above giving the number of detected entrypoints we have as part of start.

This change provides an initial indicator, that the service began execution without error, we may want to update the message to make it clear that this was from the CLI and not the users application.

![image](https://github.com/nitrictech/cli/assets/13415171/2b028f58-f8e3-4e00-a284-0389d3187174)

![image](https://github.com/nitrictech/cli/assets/13415171/8359ffcc-2b81-46ec-91ed-8aea65e7f342)
> In latest version the service name has been replaced with `nitric`
