### PR TITLE
fix: remove link border to avoid broken text wrapping

### DIFF
--- a/pkg/view/tui/commands/local/run.go
+++ b/pkg/view/tui/commands/local/run.go
@@ -221,7 +221,10 @@ func (t *TuiModel) View() string {
 	noWorkersRegistered := !apisRegistered && !websocketsRegistered && !httpProxiesRegistered && !topicsRegistered && !schedulesRegistered
 
 	if t.dashboardUrl != "" && !noWorkersRegistered {
-		v.Addln("dashboard: %s", t.dashboardUrl).WithStyle(lipgloss.NewStyle().Border(lipgloss.NormalBorder()).BorderForeground(tui.Colors.Purple).Margin(1).PaddingLeft(1).PaddingRight(1))
+		v.Break()
+		v.Add("dashboard: ").WithStyle(lipgloss.NewStyle().Foreground(tui.Colors.Purple))
+		v.Addln(t.dashboardUrl).WithStyle(lipgloss.NewStyle().Bold(true).Foreground(tui.Colors.Purple))
+		v.Break()
 	} else {
 		v.Break()
 	}

--- a/pkg/view/tui/commands/services/run.go
+++ b/pkg/view/tui/commands/services/run.go
@@ -29,6 +29,7 @@ import (
 	"github.com/nitrictech/cli/pkg/view/tui"
 	"github.com/nitrictech/cli/pkg/view/tui/commands/local"
 	"github.com/nitrictech/cli/pkg/view/tui/components/view"
+	"github.com/nitrictech/cli/pkg/view/tui/fragments"
 	"github.com/nitrictech/cli/pkg/view/tui/reactive"
 	"github.com/nitrictech/cli/pkg/view/tui/teax"
 )
@@ -221,18 +222,15 @@ func (m Model) View() string {
 
 	lv.Addln(m.localServicesModel.View())
 
-	lv.Addln("Press 'q' to quit")
-
 	rightRaw := rv.Render()
 	rightBorder := lipgloss.NewStyle().BorderForeground(tui.Colors.Gray).Border(lipgloss.NormalBorder(), false, false, false, true).PaddingLeft(1).MarginLeft(1)
 
 	finalRightView := view.New(view.WithStyle(rightBorder))
-	finalRightView.Addln("use ↑/↓ to navigate logs")
 	finalRightView.Add(tail(rightRaw, m.windowSize.Height-5, m.viewOffset))
 
 	sideBySide := lipgloss.JoinHorizontal(lipgloss.Top, lv.Render(), finalRightView.Render())
 
-	return lipgloss.NewStyle().Border(lipgloss.NormalBorder()).BorderForeground(tui.Colors.Gray).Render(sideBySide)
+	return lipgloss.NewStyle().Border(lipgloss.NormalBorder()).BorderForeground(tui.Colors.Gray).Render(sideBySide) + "\n " + fragments.Hotkey("q", "quit") + " " + fragments.Hotkey("↑/↓", "navigate logs")
 }
 
 func NewModel(stopChannel chan<- bool, updateChannel <-chan project.ServiceRunUpdate, localCloud *cloud.LocalCloud, dashboardUrl string) Model {

--- a/pkg/view/tui/fragments/hotkey.go
+++ b/pkg/view/tui/fragments/hotkey.go
@@ -29,5 +29,6 @@ import (
 func Hotkey(key string, description string) string {
 	keyView := view.NewFragment(fmt.Sprintf("%s:", key)).WithStyle(lipgloss.NewStyle().Foreground(tui.Colors.White)).Render()
 	descriptionView := view.NewFragment(description).WithStyle(lipgloss.NewStyle().Foreground(tui.Colors.Gray)).Render()
+
 	return fmt.Sprintf("%s %s", keyView, descriptionView)
 }

--- a/pkg/view/tui/fragments/hotkey.go
+++ b/pkg/view/tui/fragments/hotkey.go
@@ -1,0 +1,32 @@
+// Copyright Nitric Pty Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fragments
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/nitrictech/cli/pkg/view/tui"
+	"github.com/nitrictech/cli/pkg/view/tui/components/view"
+)
+
+// Hotkey renders a hotkey fragment e.g. q: quit
+func Hotkey(key string, description string) string {
+	keyView := view.NewFragment(fmt.Sprintf("%s:", key)).WithStyle(lipgloss.NewStyle().Foreground(tui.Colors.White)).Render()
+	descriptionView := view.NewFragment(description).WithStyle(lipgloss.NewStyle().Foreground(tui.Colors.Gray)).Render()
+	return fmt.Sprintf("%s %s", keyView, descriptionView)
+}

--- a/pkg/view/tui/fragments/hotkey.go
+++ b/pkg/view/tui/fragments/hotkey.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/lipgloss"
+
 	"github.com/nitrictech/cli/pkg/view/tui"
 	"github.com/nitrictech/cli/pkg/view/tui/components/view"
 )


### PR DESCRIPTION
Also relocates the hotkey instructions to a single place.

Before:
<img width="593" alt="nitric_start" src="https://github.com/nitrictech/cli/assets/4121391/d90aeddf-f1e9-43c4-9d01-99995997de8a">

Now:
<img width="603" alt="__code_nitric_cli_bin_nitric_start" src="https://github.com/nitrictech/cli/assets/4121391/3de3d6c9-e499-4c0c-b90f-eeb43d9b7416">

