### PR TITLE
fix: allow 'q' in text prompt component

### DIFF
--- a/pkg/view/tui/commands/build/build.go
+++ b/pkg/view/tui/commands/build/build.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -58,8 +59,8 @@ func (m Model) Init() tea.Cmd {
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		switch msg.String() {
-		case "ctrl+c", "q":
+		switch {
+		case key.Matches(msg, tui.KeyMap.Quit):
 			return m, teax.Quit
 		}
 	case tea.WindowSizeMsg:

--- a/pkg/view/tui/commands/local/run.go
+++ b/pkg/view/tui/commands/local/run.go
@@ -17,6 +17,7 @@
 package local
 
 import (
+	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
@@ -192,10 +193,8 @@ func (t *TuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch typ := msg.(type) {
 	case tea.KeyMsg:
-		keyMsg := msg.(tea.KeyMsg)
-
-		switch keyMsg.String() {
-		case "ctrl+c", "q":
+		switch {
+		case key.Matches(typ, tui.KeyMap.Quit):
 			return t, teax.Quit
 		}
 

--- a/pkg/view/tui/commands/local/startup.go
+++ b/pkg/view/tui/commands/local/startup.go
@@ -17,6 +17,7 @@
 package local
 
 import (
+	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -56,10 +57,8 @@ func (t *LocalCloudStartModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch typ := msg.(type) {
 	case tea.KeyMsg:
-		keyMsg := msg.(tea.KeyMsg)
-
-		switch keyMsg.String() {
-		case "ctrl+c", "q":
+		switch {
+		case key.Matches(typ, tui.KeyMap.Quit):
 			return t, teax.Quit
 		}
 	case LocalCloudStartStatusMsg:

--- a/pkg/view/tui/commands/services/run.go
+++ b/pkg/view/tui/commands/services/run.go
@@ -20,6 +20,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/samber/lo"
@@ -66,16 +67,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.windowSize = msg
 	case tea.KeyMsg:
-		switch msg.String() {
-		case "q", "esc", "ctrl+c":
+		switch {
+		case key.Matches(msg, tui.KeyMap.Quit):
 			func() {
 				m.stopChan <- true
 			}()
 
 			return m, teax.Quit
-		case "up":
+		case key.Matches(msg, tui.KeyMap.Up):
 			m.viewOffset++
-		case "down":
+		case key.Matches(msg, tui.KeyMap.Down):
 			m.viewOffset = max(0, m.viewOffset-1)
 		}
 	case reactive.ChanMsg[project.ServiceRunUpdate]:
@@ -230,7 +231,7 @@ func (m Model) View() string {
 
 	sideBySide := lipgloss.JoinHorizontal(lipgloss.Top, lv.Render(), finalRightView.Render())
 
-	return lipgloss.NewStyle().Border(lipgloss.NormalBorder()).BorderForeground(tui.Colors.Gray).Render(sideBySide) + "\n " + fragments.Hotkey("q", "quit") + " " + fragments.Hotkey("↑/↓", "navigate logs")
+	return lipgloss.NewStyle().Border(lipgloss.NormalBorder()).BorderForeground(tui.Colors.Gray).Render(sideBySide) + "\n " + fragments.Hotkey("esc", "quit") + " " + fragments.Hotkey("↑/↓", "navigate logs")
 }
 
 func NewModel(stopChannel chan<- bool, updateChannel <-chan project.ServiceRunUpdate, localCloud *cloud.LocalCloud, dashboardUrl string) Model {

--- a/pkg/view/tui/commands/stack/down/stack_down.go
+++ b/pkg/view/tui/commands/stack/down/stack_down.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -70,8 +71,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.windowSize = msg
 	case tea.KeyMsg:
-		switch msg.String() {
-		case "q", "esc", "ctrl+c":
+		switch {
+		case key.Matches(msg, tui.KeyMap.Quit):
 			m.done = true
 			return m, teax.Quit
 		}

--- a/pkg/view/tui/commands/stack/select/stack_select.go
+++ b/pkg/view/tui/commands/stack/select/stack_select.go
@@ -17,8 +17,10 @@
 package stack_select
 
 import (
+	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/nitrictech/cli/pkg/view/tui"
 	"github.com/nitrictech/cli/pkg/view/tui/components/list"
 	"github.com/nitrictech/cli/pkg/view/tui/components/listprompt"
 	"github.com/nitrictech/cli/pkg/view/tui/teax"
@@ -40,8 +42,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		switch msg.String() {
-		case "q", "esc", "ctrl+c":
+		switch {
+		case key.Matches(msg, tui.KeyMap.Quit):
 			return m, teax.Quit
 		}
 	}

--- a/pkg/view/tui/commands/stack/up/stack_up.go
+++ b/pkg/view/tui/commands/stack/up/stack_up.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -71,8 +72,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.windowSize = msg
 	case tea.KeyMsg:
-		switch msg.String() {
-		case "q", "esc", "ctrl+c":
+		switch {
+		case key.Matches(msg, tui.KeyMap.Quit):
 			m.done = true
 			return m, teax.Quit
 		}

--- a/pkg/view/tui/keys.go
+++ b/pkg/view/tui/keys.go
@@ -32,8 +32,8 @@ var KeyMap = DefaultKeyMap{
 		key.WithHelp("enter", "submit input"),
 	),
 	Quit: key.NewBinding(
-		key.WithKeys("q", "ctrl+c"),
-		key.WithHelp("q", "exit"),
+		key.WithKeys("esc", "ctrl+c"),
+		key.WithHelp("esc", "exit"),
 	),
 	Up: key.NewBinding(
 		key.WithKeys("up"),


### PR DESCRIPTION
Consistently use 'esc' and 'ctrl+c' for quitting instead of the 'q' to avoid issues where names include a 'q' and cause commands to exit.
