### PR TITLE
fix: ensure custom runtime build args are not overwritten

### DIFF
--- a/pkg/project/runtime/runtime.go
+++ b/pkg/project/runtime/runtime.go
@@ -83,6 +83,13 @@ func customBuildContext(entrypointFilePath string, dockerfilePath string, buildA
 	// ensure build args exists
 	if buildArgs == nil {
 		buildArgs = map[string]string{}
+	} else {
+		// Copy the build args to avoid modifying the original
+		copiedBuildArgs := map[string]string{}
+		for k, v := range buildArgs {
+			copiedBuildArgs[k] = v
+		}
+		buildArgs = copiedBuildArgs
 	}
 
 	// Append handler to build args

--- a/pkg/project/runtime/runtime.go
+++ b/pkg/project/runtime/runtime.go
@@ -89,6 +89,7 @@ func customBuildContext(entrypointFilePath string, dockerfilePath string, buildA
 		for k, v := range buildArgs {
 			copiedBuildArgs[k] = v
 		}
+
 		buildArgs = copiedBuildArgs
 	}
 


### PR DESCRIPTION
I found this bug by creating two services in golang with the custom runtime. The HANDLER arg was overwritten and all services got the same value, this fixes that.