### PR TITLE
fix: fix node builds to node v22.4.1

### DIFF
--- a/pkg/project/runtime/javascript.dockerfile
+++ b/pkg/project/runtime/javascript.dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:alpine
+FROM node:22.4.1-alpine
 
 ARG HANDLER
 ENV HANDLER=${HANDLER}

--- a/pkg/project/runtime/typescript.dockerfile
+++ b/pkg/project/runtime/typescript.dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:alpine as build
+FROM node:22.4.1-alpine as build
 
 ARG HANDLER
 
@@ -28,7 +28,7 @@ COPY . .
 RUN --mount=type=cache,sharing=private,target=/tmp/ncc-cache \
   ncc build ${HANDLER} -o lib/ -e .prisma/client -e @prisma/client -t
 
-FROM node:alpine as final
+FROM node:22.4.1-alpine as final
 
 RUN apk update && \
     apk add --no-cache ca-certificates && \


### PR DESCRIPTION
Fixes the node version to ensure we can test latest versions before releasing