### PR TITLE
fix: require docker for nitric down

### DIFF
--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -627,7 +627,7 @@ func init() {
 	tui.CheckErr(AddOptions(stackUpdateCmd, false))
 
 	// Delete Stack (Down)
-	stackCmd.AddCommand(tui.AddDependencyCheck(stackDeleteCmd, tui.Pulumi))
+	stackCmd.AddCommand(tui.AddDependencyCheck(stackDeleteCmd, tui.Pulumi, tui.Docker))
 	stackDeleteCmd.Flags().BoolVarP(&confirmDown, "yes", "y", false, "confirm the destruction of the stack")
 	tui.CheckErr(AddOptions(stackDeleteCmd, false))
 


### PR DESCRIPTION
Fixes an issue where a pulumi refresh requires docker

```
rpc error: code = Unknown desc = failed to refresh stack: exit status 0xffffffff

...

Diagnostics:
  pulumi:pulumi:Stack (demo-demo-pulumi):
    error: update failed

  docker:index:Image (demo_services-photos-image):
    error: Docker native provider returned an unexpected error from Configure: failed to connect to any docker daemon
```