### PR TITLE
feat: Add basedir to service defintion

### DIFF
--- a/pkg/project/config.go
+++ b/pkg/project/config.go
@@ -37,6 +37,9 @@ type RuntimeConfiguration struct {
 }
 
 type ServiceConfiguration struct {
+	// The base directory for source files
+	Basedir string `yaml:"basedir"`
+
 	// This is the string version
 	Match string `yaml:"match"`
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -361,8 +361,9 @@ func fromProjectConfiguration(projectConfig *ProjectConfiguration, localConfig *
 
 		for _, f := range files {
 			relativeServiceEntrypointPath, _ := filepath.Rel(filepath.Join(projectConfig.Directory, serviceSpec.Basedir), f)
+			projectRelativeServiceFile := filepath.Join(projectConfig.Directory, f)
 
-			serviceName := projectConfig.pathToNormalizedServiceName(relativeServiceEntrypointPath)
+			serviceName := projectConfig.pathToNormalizedServiceName(projectRelativeServiceFile)
 
 			var buildContext *runtime.RuntimeBuildContext
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -354,6 +354,7 @@ func fromProjectConfiguration(projectConfig *ProjectConfiguration, localConfig *
 
 	for _, serviceSpec := range projectConfig.Services {
 		serviceMatch := filepath.Join(serviceSpec.Basedir, serviceSpec.Match)
+
 		files, err := afero.Glob(fs, serviceMatch)
 		if err != nil {
 			return nil, fmt.Errorf("unable to match service files for pattern %s: %w", serviceMatch, err)

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -285,7 +285,7 @@ func (p *Project) RunServicesWithCommand(localCloud *cloud.LocalCloud, stop <-ch
 
 		// start the service with the given file reference from its projects CWD
 		group.Go(func() error {
-			port, err := localCloud.AddService(svc.filepath)
+			port, err := localCloud.AddService(svc.GetFilePath())
 			if err != nil {
 				return err
 			}
@@ -319,7 +319,7 @@ func (p *Project) RunServices(localCloud *cloud.LocalCloud, stop <-chan bool, up
 		svc := service
 
 		group.Go(func() error {
-			port, err := localCloud.AddService(svc.filepath)
+			port, err := localCloud.AddService(svc.GetFilePath())
 			if err != nil {
 				return err
 			}

--- a/pkg/project/runtime/runtime.go
+++ b/pkg/project/runtime/runtime.go
@@ -108,13 +108,13 @@ func customBuildContext(entrypointFilePath string, dockerfilePath string, baseDi
 var csharpDockerfile string
 var csharpIgnores = append([]string{"obj/", "bin/"}, commonIgnore...)
 
-func csharpBuildContext(entrypointFilePath string, additionalIgnores []string) (*RuntimeBuildContext, error) {
+func csharpBuildContext(entrypointFilePath string, baseDir string, additionalIgnores []string) (*RuntimeBuildContext, error) {
 	// Convert the service name to the name of the binary produced. i.e. services/hello.csproj -> hello
 	handler := strings.ReplaceAll(filepath.Base(entrypointFilePath), ".csproj", "")
 
 	return &RuntimeBuildContext{
 		DockerfileContents: csharpDockerfile,
-		BaseDirectory:      ".", // use the nitric project directory
+		BaseDirectory:      baseDir, // use the nitric project directory
 		BuildArguments: map[string]string{
 			"HANDLER": handler,
 		},
@@ -126,10 +126,10 @@ func csharpBuildContext(entrypointFilePath string, additionalIgnores []string) (
 var jvmDockerfile string
 var jvmIgnores = append([]string{"obj/", "bin/"}, commonIgnore...)
 
-func jvmBuildContext(entrypointFilePath string, additionalIgnores []string) (*RuntimeBuildContext, error) {
+func jvmBuildContext(entrypointFilePath string, baseDir string, additionalIgnores []string) (*RuntimeBuildContext, error) {
 	return &RuntimeBuildContext{
 		DockerfileContents: jvmDockerfile,
-		BaseDirectory:      ".", // use the nitric project directory
+		BaseDirectory:      baseDir, // use the nitric project directory
 		BuildArguments: map[string]string{
 			"HANDLER": filepath.ToSlash(entrypointFilePath),
 		},
@@ -141,10 +141,10 @@ func jvmBuildContext(entrypointFilePath string, additionalIgnores []string) (*Ru
 var pythonDockerfile string
 var pythonIgnores = append([]string{"__pycache__/", "*.py[cod]", "*$py.class"}, commonIgnore...)
 
-func pythonBuildContext(entrypointFilePath string, additionalIgnores []string) (*RuntimeBuildContext, error) {
+func pythonBuildContext(entrypointFilePath string, baseDir string, additionalIgnores []string) (*RuntimeBuildContext, error) {
 	return &RuntimeBuildContext{
 		DockerfileContents: pythonDockerfile,
-		BaseDirectory:      ".", // use the nitric project directory
+		BaseDirectory:      baseDir, // use the nitric project directory
 		BuildArguments: map[string]string{
 			"HANDLER": filepath.ToSlash(entrypointFilePath),
 		},
@@ -156,10 +156,10 @@ func pythonBuildContext(entrypointFilePath string, additionalIgnores []string) (
 var javascriptDockerfile string
 var javascriptIgnores = append([]string{"node_modules/"}, commonIgnore...)
 
-func javascriptBuildContext(entrypointFilePath string, additionalIgnores []string) (*RuntimeBuildContext, error) {
+func javascriptBuildContext(entrypointFilePath string, baseDir string, additionalIgnores []string) (*RuntimeBuildContext, error) {
 	return &RuntimeBuildContext{
 		DockerfileContents: javascriptDockerfile,
-		BaseDirectory:      ".", // use the nitric project directory
+		BaseDirectory:      baseDir, // use the nitric project directory
 		BuildArguments: map[string]string{
 			"HANDLER": filepath.ToSlash(entrypointFilePath),
 		},
@@ -170,10 +170,10 @@ func javascriptBuildContext(entrypointFilePath string, additionalIgnores []strin
 //go:embed typescript.dockerfile
 var typescriptDockerfile string
 
-func typescriptBuildContext(entrypointFilePath string, additionalIgnores []string) (*RuntimeBuildContext, error) {
+func typescriptBuildContext(entrypointFilePath string, baseDir string, additionalIgnores []string) (*RuntimeBuildContext, error) {
 	return &RuntimeBuildContext{
 		DockerfileContents: typescriptDockerfile,
-		BaseDirectory:      ".", // use the nitric project directory
+		BaseDirectory:      baseDir, // use the nitric project directory
 		BuildArguments: map[string]string{
 			"HANDLER": filepath.ToSlash(entrypointFilePath),
 		},
@@ -185,10 +185,10 @@ func typescriptBuildContext(entrypointFilePath string, additionalIgnores []strin
 var dartDockerfile string
 var dartIgnores = append([]string{}, commonIgnore...)
 
-func dartBuildContext(entrypointFilePath string, additionalIgnores []string) (*RuntimeBuildContext, error) {
+func dartBuildContext(entrypointFilePath string, baseDir string, additionalIgnores []string) (*RuntimeBuildContext, error) {
 	return &RuntimeBuildContext{
 		DockerfileContents: dartDockerfile,
-		BaseDirectory:      ".", // use the nitric project directory
+		BaseDirectory:      baseDir, // use the nitric project directory
 		BuildArguments: map[string]string{
 			"HANDLER": filepath.ToSlash(entrypointFilePath),
 		},
@@ -233,17 +233,17 @@ func NewBuildContext(entrypointFilePath string, dockerfilePath string, baseDirec
 
 	switch ext {
 	case ".csproj":
-		return csharpBuildContext(entrypointFilePath, additionalIgnores)
+		return csharpBuildContext(entrypointFilePath, baseDirectory, additionalIgnores)
 	case ".jar":
-		return jvmBuildContext(entrypointFilePath, additionalIgnores)
+		return jvmBuildContext(entrypointFilePath, baseDirectory, additionalIgnores)
 	case ".py":
-		return pythonBuildContext(entrypointFilePath, additionalIgnores)
+		return pythonBuildContext(entrypointFilePath, baseDirectory, additionalIgnores)
 	case ".js":
-		return javascriptBuildContext(entrypointFilePath, additionalIgnores)
+		return javascriptBuildContext(entrypointFilePath, baseDirectory, additionalIgnores)
 	case ".ts":
-		return typescriptBuildContext(entrypointFilePath, additionalIgnores)
+		return typescriptBuildContext(entrypointFilePath, baseDirectory, additionalIgnores)
 	case ".dart":
-		return dartBuildContext(entrypointFilePath, additionalIgnores)
+		return dartBuildContext(entrypointFilePath, baseDirectory, additionalIgnores)
 	default:
 		return nil, fmt.Errorf("nitric does not support files with extension %s by default", ext)
 	}

--- a/pkg/project/service.go
+++ b/pkg/project/service.go
@@ -373,7 +373,7 @@ func (s *Service) RunContainer(stop <-chan bool, updates chan<- ServiceRunUpdate
 	if err != nil {
 		updates <- ServiceRunUpdate{
 			ServiceName: s.Name,
-			Label:       s.filepath,
+			Label:       s.GetFilePath(),
 			Status:      ServiceRunStatus_Error,
 			Err:         err,
 		}
@@ -385,7 +385,7 @@ func (s *Service) RunContainer(stop <-chan bool, updates chan<- ServiceRunUpdate
 	if err != nil {
 		updates <- ServiceRunUpdate{
 			ServiceName: s.Name,
-			Label:       s.filepath,
+			Label:       s.GetFilePath(),
 			Status:      ServiceRunStatus_Error,
 			Err:         err,
 		}
@@ -395,7 +395,7 @@ func (s *Service) RunContainer(stop <-chan bool, updates chan<- ServiceRunUpdate
 
 	updates <- ServiceRunUpdate{
 		ServiceName: s.Name,
-		Label:       s.filepath,
+		Label:       s.GetFilePath(),
 		Message:     fmt.Sprintf("Service %s started", s.Name),
 		Status:      ServiceRunStatus_Running,
 	}
@@ -419,7 +419,7 @@ func (s *Service) RunContainer(stop <-chan bool, updates chan<- ServiceRunUpdate
 		_, err := io.Copy(writerFunc(func(p []byte) (int, error) {
 			updates <- ServiceRunUpdate{
 				ServiceName: s.Name,
-				Label:       s.filepath,
+				Label:       s.GetFilePath(),
 				Message:     string(p),
 				Status:      ServiceRunStatus_Running,
 			}
@@ -429,7 +429,7 @@ func (s *Service) RunContainer(stop <-chan bool, updates chan<- ServiceRunUpdate
 		if err != nil {
 			updates <- ServiceRunUpdate{
 				ServiceName: s.Name,
-				Label:       s.filepath,
+				Label:       s.GetFilePath(),
 				Status:      ServiceRunStatus_Error,
 				Err:         err,
 			}
@@ -443,7 +443,7 @@ func (s *Service) RunContainer(stop <-chan bool, updates chan<- ServiceRunUpdate
 		case err := <-errChan:
 			updates <- ServiceRunUpdate{
 				ServiceName: s.Name,
-				Label:       s.filepath,
+				Label:       s.GetFilePath(),
 				Err:         err,
 				Status:      ServiceRunStatus_Error,
 			}
@@ -476,7 +476,7 @@ func (s *Service) RunContainer(stop <-chan bool, updates chan<- ServiceRunUpdate
 				return err
 			} else {
 				updates <- ServiceRunUpdate{
-					Label:       s.filepath,
+					Label:       s.GetFilePath(),
 					ServiceName: s.Name,
 					Message:     "Service successfully exited",
 					Status:      ServiceRunStatus_Done,
@@ -487,7 +487,7 @@ func (s *Service) RunContainer(stop <-chan bool, updates chan<- ServiceRunUpdate
 		case <-stop:
 			if err := dockerClient.ContainerStop(context.Background(), containerId, container.StopOptions{}); err != nil {
 				updates <- ServiceRunUpdate{
-					Label:       s.filepath,
+					Label:       s.GetFilePath(),
 					ServiceName: s.Name,
 					Status:      ServiceRunStatus_Error,
 					Err:         err,

--- a/pkg/project/service.go
+++ b/pkg/project/service.go
@@ -48,6 +48,7 @@ type Service struct {
 	Type string
 
 	// filepath relative to the project root directory
+	basedir      string
 	filepath     string
 	buildContext runtime.RuntimeBuildContext
 
@@ -55,11 +56,11 @@ type Service struct {
 }
 
 func (s *Service) GetFilePath() string {
-	return s.filepath
+	return filepath.Join(s.basedir, s.filepath)
 }
 
 func (s *Service) GetAbsoluteFilePath() (string, error) {
-	return filepath.Abs(s.filepath)
+	return filepath.Abs(s.GetFilePath())
 }
 
 const (
@@ -239,6 +240,7 @@ func (s *Service) Run(stop <-chan bool, updates chan<- ServiceRunUpdate, env map
 	)
 
 	cmd.Env = append([]string{}, os.Environ()...)
+	cmd.Dir = s.basedir
 
 	for k, v := range env {
 		cmd.Env = append(cmd.Env, k+"="+v)
@@ -247,14 +249,14 @@ func (s *Service) Run(stop <-chan bool, updates chan<- ServiceRunUpdate, env map
 	cmd.Stdout = &ServiceRunUpdateWriter{
 		updates:     updates,
 		serviceName: s.Name,
-		label:       s.filepath,
+		label:       s.GetFilePath(),
 		status:      ServiceRunStatus_Running,
 	}
 
 	cmd.Stderr = &ServiceRunUpdateWriter{
 		updates:     updates,
 		serviceName: s.Name,
-		label:       s.filepath,
+		label:       s.GetFilePath(),
 		status:      ServiceRunStatus_Error,
 	}
 


### PR DESCRIPTION
If a custom runtime is specfied its "context" property will override basedir, if it is not blank, otherwise it will simply use basedir as context. basedir defaults to "" which is functionally identical to "."