### PR TITLE
add function for adding format strings to tui start output 

### DIFF
--- a/pkg/view/tui/commands/build/build.go
+++ b/pkg/view/tui/commands/build/build.go
@@ -160,7 +160,7 @@ func (m Model) View() string {
 				statusColor = tui.Colors.Red
 			}
 
-			serviceUpdates.Add("%s ", serviceName)
+			serviceUpdates.Addf("%s ", serviceName)
 			serviceUpdates.Addln(strings.ToLower(string(latestUpdate.Status))).WithStyle(lipgloss.NewStyle().Foreground(statusColor))
 		}
 

--- a/pkg/view/tui/commands/local/run.go
+++ b/pkg/view/tui/commands/local/run.go
@@ -266,22 +266,22 @@ func (t *TuiModel) View() string {
 	}
 
 	for _, api := range t.apis {
-		v.Add("api:%s - ", api.Name)
+		v.Addf("api:%s - ", api.Name)
 		v.Addln(api.Url).WithStyle(lipgloss.NewStyle().Bold(true).Foreground(tui.Colors.Purple))
 	}
 
 	for _, httpProxy := range t.httpProxies {
-		v.Add("http:%s - ", httpProxy.name)
+		v.Addf("http:%s - ", httpProxy.name)
 		v.Addln(httpProxy.url).WithStyle(lipgloss.NewStyle().Bold(true).Foreground(tui.Colors.Purple))
 	}
 
 	for _, websocket := range t.websockets {
-		v.Add("ws:%s - ", websocket.name)
+		v.Addf("ws:%s - ", websocket.name)
 		v.Addln(websocket.url).WithStyle(lipgloss.NewStyle().Bold(true).Foreground(tui.Colors.Purple))
 	}
 
 	for _, database := range t.databases {
-		v.Add("db:%s - ", database.name)
+		v.Addf("db:%s - ", database.name)
 		v.Addln(database.status).WithStyle(lipgloss.NewStyle().Bold(true).Foreground(tui.Colors.Purple))
 	}
 

--- a/pkg/view/tui/commands/local/startup.go
+++ b/pkg/view/tui/commands/local/startup.go
@@ -85,7 +85,7 @@ func (t *LocalCloudStartModel) View() string {
 		if t.isNonInteractive {
 			v.Add("Starting Local Cloud, if this is your first run this may take a few minutes")
 		} else {
-			v.Add("%s Starting Local Cloud, if this is your first run this may take a few minutes", t.spinner.View())
+			v.Addf("%s Starting Local Cloud, if this is your first run this may take a few minutes", t.spinner.View())
 		}
 	} else {
 		v.Add("Local cloud started successfully")

--- a/pkg/view/tui/commands/services/run.go
+++ b/pkg/view/tui/commands/services/run.go
@@ -190,7 +190,7 @@ func (m Model) View() string {
 	if len(m.serviceStatus) == 0 {
 		lv.Addln("No service found in project, check your nitric.yaml file contains at least one valid 'match' pattern.")
 	} else {
-		lv.Add("%d", len(m.serviceStatus)).WithStyle(lipgloss.NewStyle().Bold(true).Foreground(tui.Colors.Purple))
+		lv.Addf("%d", len(m.serviceStatus)).WithStyle(lipgloss.NewStyle().Bold(true).Foreground(tui.Colors.Purple))
 		lv.Addln(" services registered with local nitric server")
 	}
 
@@ -209,7 +209,7 @@ func (m Model) View() string {
 			statusColor = tui.Colors.Red
 		}
 
-		rv.Add("%s: ", update.Label).WithStyle(lipgloss.NewStyle().Foreground(svcColors[update.ServiceName]))
+		rv.Addf("%s: ", update.Label).WithStyle(lipgloss.NewStyle().Foreground(svcColors[update.ServiceName]))
 
 		// Break the message into multiple lines so the foreground colour can be maintained
 

--- a/pkg/view/tui/commands/stack/down/stack_down.go
+++ b/pkg/view/tui/commands/stack/down/stack_down.go
@@ -189,7 +189,7 @@ func (m Model) View() string {
 	v.Break()
 
 	v.Add(fragments.Tag("down"))
-	v.Add("  tearing down with %s", m.provider)
+	v.Addf("  tearing down with %s", m.provider)
 
 	if m.done {
 		v.Break()

--- a/pkg/view/tui/commands/stack/up/stack_up.go
+++ b/pkg/view/tui/commands/stack/up/stack_up.go
@@ -178,7 +178,7 @@ func (m Model) View() string {
 	v := view.New(view.WithStyle(lipgloss.NewStyle().Width(m.windowSize.Width)))
 	v.Break()
 	v.Add(fragments.Tag("up"))
-	v.Add("  Deploying with %s", m.provider)
+	v.Addf("  Deploying with %s", m.provider)
 
 	if m.done {
 		v.Break()

--- a/pkg/view/tui/components/view/view.go
+++ b/pkg/view/tui/components/view/view.go
@@ -29,8 +29,16 @@ type View struct {
 	newline   string
 }
 
+// Add the fragment to the view
+func (v *View) Add(contents string) *Fragment {
+	f := NewFragment(contents)
+	v.fragments = append(v.fragments, f)
+
+	return f
+}
+
 // Add formats according to a format specifier and appends the resulting string to the view.
-func (v *View) Add(format string, a ...any) *Fragment {
+func (v *View) Addf(format string, a ...any) *Fragment {
 	f := NewFragment(fmt.Sprintf(format, a...))
 	v.fragments = append(v.fragments, f)
 
@@ -44,7 +52,7 @@ func (v *View) Break() {
 
 // Addln formats according to a format specifier and appends the resulting string to the view, followed by a new line.
 func (v *View) Addln(format string, a ...any) *Fragment {
-	fragment := v.Add(format, a...)
+	fragment := v.Addf(format, a...)
 
 	v.Break()
 


### PR DESCRIPTION
Fix the occurence where logs that contain `%` expects a variable in the `fmt.Sprintf` call. 

![Cursor_and_py-stable-diff__hello_py](https://github.com/user-attachments/assets/4cf40148-0980-46da-b7c4-c8b79b2958d9)
