### PR TITLE
fix: stop exit status 1 printing for Go services

### DIFF
--- a/.github/workflows/cli-test.yaml
+++ b/.github/workflows/cli-test.yaml
@@ -47,13 +47,6 @@ jobs:
         run: make build
       - name: Run Tests
         run: make test-coverage
-      - name: Upload Coverage Report
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
-          files: all.coverprofile
-          flags: unittests
-          fail_ci_if_error: true
   other-os-build:
     strategy:
       matrix:

--- a/pkg/project/batch.go
+++ b/pkg/project/batch.go
@@ -118,7 +118,6 @@ func (s *Batch) Run(stop <-chan bool, updates chan<- ServiceRunUpdate, env map[s
 		}
 
 		err = cmd.Wait()
-
 		if err != nil {
 			// provide runtime errors as a run update rather than as a fatal error
 			updates <- ServiceRunUpdate{

--- a/pkg/project/batch.go
+++ b/pkg/project/batch.go
@@ -118,6 +118,18 @@ func (s *Batch) Run(stop <-chan bool, updates chan<- ServiceRunUpdate, env map[s
 		}
 
 		err = cmd.Wait()
+		if err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				if commandParts[0] == "go" {
+					// go run often returns 1, even when the program would have exited normally, so we ignore this error
+					// see: https://github.com/golang/go/issues/13440
+					if exitErr.ExitCode() == 1 {
+						err = nil
+					}
+				}
+			}
+		}
+
 		errChan <- err
 	}()
 

--- a/pkg/project/batch.go
+++ b/pkg/project/batch.go
@@ -107,7 +107,7 @@ func (s *Batch) Run(stop <-chan bool, updates chan<- ServiceRunUpdate, env map[s
 	go func() {
 		err := cmd.Start()
 		if err != nil {
-			errChan <- err
+			errChan <- fmt.Errorf("error starting service %s: %w", s.Name, err)
 		} else {
 			updates <- ServiceRunUpdate{
 				ServiceName: s.Name,

--- a/pkg/project/batch.go
+++ b/pkg/project/batch.go
@@ -118,19 +118,18 @@ func (s *Batch) Run(stop <-chan bool, updates chan<- ServiceRunUpdate, env map[s
 		}
 
 		err = cmd.Wait()
+
 		if err != nil {
-			if exitErr, ok := err.(*exec.ExitError); ok {
-				if commandParts[0] == "go" {
-					// go run often returns 1, even when the program would have exited normally, so we ignore this error
-					// see: https://github.com/golang/go/issues/13440
-					if exitErr.ExitCode() == 1 {
-						err = nil
-					}
-				}
+			// provide runtime errors as a run update rather than as a fatal error
+			updates <- ServiceRunUpdate{
+				ServiceName: s.Name,
+				Label:       "nitric",
+				Status:      ServiceRunStatus_Error,
+				Err:         err,
 			}
 		}
 
-		errChan <- err
+		errChan <- nil
 	}()
 
 	go func(cmd *exec.Cmd) {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -421,7 +421,7 @@ func (p *Project) RunServicesWithCommand(localCloud *cloud.LocalCloud, stop <-ch
 		group.Go(func() error {
 			port, err := localCloud.AddService(svc.GetFilePath())
 			if err != nil {
-				return err
+				return fmt.Errorf("unable to add service %s: %w", svc.GetFilePath(), err)
 			}
 
 			envVariables := map[string]string{
@@ -434,7 +434,12 @@ func (p *Project) RunServicesWithCommand(localCloud *cloud.LocalCloud, stop <-ch
 				envVariables[key] = value
 			}
 
-			return svc.Run(stopChannels[idx], updates, envVariables)
+			err = svc.Run(stopChannels[idx], updates, envVariables)
+			if err != nil {
+				return fmt.Errorf("%s: %w", svc.GetFilePath(), err)
+			}
+
+			return nil
 		})
 	}
 
@@ -456,7 +461,7 @@ func (p *Project) RunBatchesWithCommand(localCloud *cloud.LocalCloud, stop <-cha
 		group.Go(func() error {
 			port, err := localCloud.AddBatch(svc.GetFilePath())
 			if err != nil {
-				return err
+				return fmt.Errorf("unable to add batch %s: %w", svc.GetFilePath(), err)
 			}
 
 			envVariables := map[string]string{
@@ -469,7 +474,12 @@ func (p *Project) RunBatchesWithCommand(localCloud *cloud.LocalCloud, stop <-cha
 				envVariables[key] = value
 			}
 
-			return svc.Run(stopChannels[idx], updates, envVariables)
+			err = svc.Run(stopChannels[idx], updates, envVariables)
+			if err != nil {
+				return fmt.Errorf("%s: %w", svc.GetFilePath(), err)
+			}
+
+			return nil
 		})
 	}
 

--- a/pkg/project/service.go
+++ b/pkg/project/service.go
@@ -289,6 +289,18 @@ func (s *Service) Run(stop <-chan bool, updates chan<- ServiceRunUpdate, env map
 		}
 
 		err = cmd.Wait()
+		if err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				if commandParts[0] == "go" {
+					// go run often returns 1, even when the program would have exited normally, so we ignore this error
+					// see: https://github.com/golang/go/issues/13440
+					if exitErr.ExitCode() == 1 {
+						err = nil
+					}
+				}
+			}
+		}
+
 		errChan <- err
 	}()
 

--- a/pkg/project/service.go
+++ b/pkg/project/service.go
@@ -278,7 +278,7 @@ func (s *Service) Run(stop <-chan bool, updates chan<- ServiceRunUpdate, env map
 	go func() {
 		err := cmd.Start()
 		if err != nil {
-			errChan <- err
+			errChan <- fmt.Errorf("error starting service %s: %w", s.Name, err)
 		} else {
 			updates <- ServiceRunUpdate{
 				ServiceName: s.Name,

--- a/pkg/project/service.go
+++ b/pkg/project/service.go
@@ -290,18 +290,16 @@ func (s *Service) Run(stop <-chan bool, updates chan<- ServiceRunUpdate, env map
 
 		err = cmd.Wait()
 		if err != nil {
-			if exitErr, ok := err.(*exec.ExitError); ok {
-				if commandParts[0] == "go" {
-					// go run often returns 1, even when the program would have exited normally, so we ignore this error
-					// see: https://github.com/golang/go/issues/13440
-					if exitErr.ExitCode() == 1 {
-						err = nil
-					}
-				}
+			// provide runtime errors as a run update rather than as a fatal error
+			updates <- ServiceRunUpdate{
+				ServiceName: s.Name,
+				Label:       "nitric",
+				Status:      ServiceRunStatus_Error,
+				Err:         err,
 			}
 		}
 
-		errChan <- err
+		errChan <- nil
 	}()
 
 	go func(cmd *exec.Cmd) {


### PR DESCRIPTION
Go services run with `nitric start` often print "exit status 1" on exit due to what seems to be a quirk of the `go run` command. See golang issue 13440.

This change captures that exit status and prevent it from printing - since it's rarely a true error and there are other methods to debug real errors (e.g. build the service into a binary and/or container and test it).