### PR TITLE
fix: make list heights responsive to terminal height

### DIFF
--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -70,25 +70,6 @@ nitric stack list
 		if cmd.Root().PersistentPreRun != nil {
 			cmd.Root().PersistentPreRun(cmd, args)
 		}
-
-		// Respect existing pulumi configuration if one already exists
-		// currPass := os.Getenv("PULUMI_CONFIG_PASSPHRASE")
-		// currPassFile := os.Getenv("PULUMI_CONFIG_PASSPHRASE_FILE")
-		// if currPass == "" && currPassFile == "" {
-		// 	p, err := preferences.GetLocalPassPhraseFile()
-		// 	// In non-CI environments we can generate the file to save a step.
-		// 	// in CI environments this file would typically be lost, so it shouldn't auto-generate
-		// 	if err != nil && !output.CI {
-		// 		p, err = preferences.GenerateLocalPassPhraseFile()
-		// 	}
-		// 	if err != nil {
-		// 		err = fmt.Errorf("unable to determine configured passphrase. See https://nitric.io/docs/guides/github-actions#configuring-environment-variables")
-		// 	}
-		// 	utils.CheckErr(err)
-
-		// 	// Set the default
-		// 	os.Setenv("PULUMI_CONFIG_PASSPHRASE_FILE", p)
-		// }
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/samber/lo v1.38.1
 	github.com/spf13/afero v1.11.0
+	github.com/stretchr/testify v1.9.0
 	github.com/wk8/go-ordered-map/v2 v2.1.8
 	go.etcd.io/bbolt v1.3.6
 	golang.org/x/sync v0.8.0
@@ -249,7 +250,6 @@ require (
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.1.1 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/tdakkota/asciicheck v0.2.0 // indirect
 	github.com/tetafro/godot v1.4.17 // indirect

--- a/pkg/view/tui/commands/stack/new/stack_new.go
+++ b/pkg/view/tui/commands/stack/new/stack_new.go
@@ -325,12 +325,6 @@ func New(fs afero.Fs, args Args) Model {
 	})
 	namePrompt.Focus()
 
-	listItems := []list.ListItem{}
-
-	for _, provider := range availableProviders {
-		listItems = append(listItems, &ListItem{Value: provider})
-	}
-
 	providerPrompt := listprompt.NewListPrompt(listprompt.ListPromptArgs{
 		Prompt: "Which provider do you want to deploy with?",
 		Tag:    "prov",

--- a/pkg/view/tui/commands/stack/up/stack_up.go
+++ b/pkg/view/tui/commands/stack/up/stack_up.go
@@ -36,6 +36,8 @@ import (
 )
 
 type Model struct {
+	windowSize tea.WindowSizeMsg
+
 	provider           string
 	stack              *stack.Resource
 	defaultParent      *stack.Resource
@@ -48,8 +50,6 @@ type Model struct {
 	resultOutput       string
 
 	done bool
-
-	windowSize tea.WindowSizeMsg
 
 	spinner spinner.Model
 }
@@ -71,6 +71,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.windowSize = msg
+
+		return m, nil
 	case tea.KeyMsg:
 		switch {
 		case key.Matches(msg, tui.KeyMap.Quit):

--- a/pkg/view/tui/components/list/sliceview.go
+++ b/pkg/view/tui/components/list/sliceview.go
@@ -1,0 +1,164 @@
+// Copyright Nitric Pty Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+// SliceView sliding window view of a list of items
+// e.g. a list of items that can be displayed in a terminal window, but not all at once
+// It keeps track of the cursor position and the view window, ensuring the cursor is always visible in the sub-slice of items
+type SliceView[T any] struct {
+	items []T
+	// max is the maximum number of items to display, if 0 or less, it will display all items
+	max int
+	// cursor is the index of the currently selected item
+	cursor int
+	// viewCursor is the index of the first item displayed in the view
+	viewCursor int
+}
+
+func (m *SliceView[T]) UpdateItems(items []T) {
+	m.items = items
+	m.cursor = 0
+	m.viewCursor = 0
+}
+
+// NumDisplayed is the number of items that will be displayed
+// based on max and total number of items
+func (m SliceView[T]) NumDisplayed() int {
+	if m.max <= 0 {
+		return len(m.items)
+	}
+
+	return min(m.max, len(m.items))
+}
+
+func NewSliceView[T any](items []T) SliceView[T] {
+	return SliceView[T]{
+		items:      items,
+		max:        len(items),
+		cursor:     0,
+		viewCursor: 0,
+	}
+}
+
+func (m *SliceView[T]) scrollIntoView(i int) {
+	vStart, vEnd := m.ViewBounds()
+
+	if vEnd >= len(m.items) {
+		m.viewCursor = len(m.items) - m.NumDisplayed()
+	}
+
+	if vStart < 0 {
+		m.viewCursor = 0
+	}
+
+	if i < vStart {
+		m.viewCursor = i
+	} else if i >= vEnd {
+		m.viewCursor = i - m.NumDisplayed() + 1
+	}
+}
+
+// ViewBounds returns the start and end index of the view
+func (m SliceView[T]) ViewBounds() (int, int) {
+	return m.viewCursor, m.viewCursor + m.NumDisplayed()
+}
+
+func (m *SliceView[T]) IsInView(i int) bool {
+	return i >= m.viewCursor && i < m.viewCursor+m.NumDisplayed()
+}
+
+// SetCursor sets the cursor to the specified index, updating the view as needed
+// if the cursor is out of bounds, it will wrap around
+func (m *SliceView[T]) SetCursor(cursor int) {
+	// Clamp the cursor to the bounds of the items
+	if cursor < 0 {
+		cursor = len(m.items) - 1
+	} else if cursor >= len(m.items) {
+		cursor = 0
+	}
+
+	m.cursor = cursor
+
+	m.scrollIntoView(cursor)
+}
+
+// CursorUp moves the cursor up, wrapping around if it reaches the top
+// it also updates the view to ensure the cursor is always visible
+func (m *SliceView[T]) CursorBack() {
+	m.SetCursor(m.cursor - 1)
+}
+
+// CursorDown moves the cursor down, wrapping around if it reaches the bottom
+// it also updates the view to ensure the cursor is always visible
+func (m *SliceView[T]) CursorNext() {
+	m.SetCursor(m.cursor + 1)
+}
+
+// Choice returns the currently selected item
+func (m SliceView[T]) Choice() T {
+	return m.items[m.cursor]
+}
+
+// SetMaxDisplayedItems sets the maximum number of items to display
+// if max is 0 or less, it will display all items
+func (m *SliceView[T]) SetMaxDisplayedItems(max int) {
+	m.max = min(max, len(m.items))
+
+	m.scrollIntoView(m.cursor)
+}
+
+// All returns all items
+func (m SliceView[T]) All() []T {
+	return m.items
+}
+
+// Cursor returns the index of the currently selected item
+func (m SliceView[T]) Cursor() int {
+	return m.cursor
+}
+
+// MaxDisplayedItems returns the maximum number of items to display
+// Use NumDisplayed to get the actual number of items that will be displayed
+func (m SliceView[T]) MaxDisplayedItems() int {
+	return m.max
+}
+
+// IsChoice returns true if the index is the currently selected item
+func (m SliceView[T]) IsChoice(i int) bool {
+	return i == m.cursor
+}
+
+// IsChoiceRelative returns true if the index is the currently selected item
+// where the index is relative to the view sub-slice
+func (m SliceView[T]) IsChoiceRelative(relativeI int) bool {
+	i := relativeI + m.viewCursor
+	return m.IsChoice(i)
+}
+
+// View returns the items that should be displayed
+func (m SliceView[T]) View() []T {
+	if m.NumDisplayed() == len(m.items) {
+		return m.items
+	}
+
+	return m.items[m.viewCursor : m.viewCursor+m.NumDisplayed()]
+}
+
+// ViewOffset returns the index of the first item displayed in the view
+func (m SliceView[T]) ViewOffset() int {
+	return m.viewCursor
+}

--- a/pkg/view/tui/components/list/sliceview_test.go
+++ b/pkg/view/tui/components/list/sliceview_test.go
@@ -19,8 +19,9 @@ package list_test
 import (
 	"testing"
 
-	"github.com/nitrictech/cli/pkg/view/tui/components/list"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/nitrictech/cli/pkg/view/tui/components/list"
 )
 
 func TestNewSliceView(t *testing.T) {

--- a/pkg/view/tui/components/list/sliceview_test.go
+++ b/pkg/view/tui/components/list/sliceview_test.go
@@ -1,0 +1,117 @@
+// Copyright Nitric Pty Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list_test
+
+import (
+	"testing"
+
+	"github.com/nitrictech/cli/pkg/view/tui/components/list"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSliceView(t *testing.T) {
+	items := []string{"item1", "item2", "item3"}
+	view := list.NewSliceView(items)
+
+	assert.Equal(t, 3, view.NumDisplayed(), "Expected number of displayed items to be 3")
+	assert.Equal(t, 0, view.Cursor(), "Expected initial cursor position to be 0")
+	assert.Equal(t, items, view.All(), "Expected all items to match input items")
+}
+
+func TestCursorMovement(t *testing.T) {
+	items := []string{"item1", "item2", "item3"}
+	view := list.NewSliceView(items)
+
+	view.CursorNext()
+	assert.Equal(t, 1, view.Cursor(), "Expected cursor to move down to 1")
+
+	view.CursorNext()
+	assert.Equal(t, 2, view.Cursor(), "Expected cursor to move down to 2")
+
+	view.CursorNext()
+	assert.Equal(t, 0, view.Cursor(), "Expected cursor to wrap around to 0")
+
+	view.CursorBack()
+	assert.Equal(t, 2, view.Cursor(), "Expected cursor to wrap around up to 2")
+
+	view.CursorBack()
+	assert.Equal(t, 1, view.Cursor(), "Expected cursor to move up to 1")
+}
+
+func TestSetMaxDisplayedItems(t *testing.T) {
+	items := []string{"item1", "item2", "item3", "item4", "item5"}
+	view := list.NewSliceView(items)
+
+	view.SetMaxDisplayedItems(3)
+	assert.Equal(t, 3, view.MaxDisplayedItems(), "Expected max displayed items to be set to 3")
+	assert.Equal(t, 3, view.NumDisplayed(), "Expected number of displayed items to be 3")
+}
+
+func TestShrinkGrowMaxDisplayedItems(t *testing.T) {
+	items := []string{"item1", "item2", "item3", "item4", "item5"}
+	view := list.NewSliceView(items)
+	view.SetCursor(2)
+
+	view.SetMaxDisplayedItems(4)
+	assert.Equal(t, 4, view.NumDisplayed(), "Expected number of displayed items to be 4")
+	assert.Equal(t, []string{"item1", "item2", "item3", "item4"}, view.View(), "Expected view to display the first 4 items")
+
+	view.SetMaxDisplayedItems(3)
+	assert.Equal(t, 3, view.NumDisplayed(), "Expected number of displayed items to be 3")
+	assert.Equal(t, []string{"item1", "item2", "item3"}, view.View(), "Expect the view end to be trimmed by 1")
+
+	view.SetMaxDisplayedItems(2)
+	assert.Equal(t, 2, view.NumDisplayed(), "Expected number of displayed items to be 2")
+	assert.Equal(t, []string{"item2", "item3"}, view.View(), "Expected view to move by 1 to keep the cursor in view")
+
+	view.SetMaxDisplayedItems(1)
+	assert.Equal(t, 1, view.NumDisplayed(), "Expected number of displayed items to be 1")
+	assert.Equal(t, []string{"item3"}, view.View(), "Expected view to move by 1 to keep the cursor in view")
+
+	view.SetMaxDisplayedItems(2)
+	assert.Equal(t, 2, view.NumDisplayed(), "Expected number of displayed items to be 2")
+	assert.Equal(t, []string{"item3", "item4"}, view.View(), "Expected view to expand by 1, keeping the cursor in view")
+
+	view.SetMaxDisplayedItems(3)
+	assert.Equal(t, 3, view.NumDisplayed(), "Expected number of displayed items to be 3")
+	assert.Equal(t, []string{"item3", "item4", "item5"}, view.View(), "Expected view to expand by 1, keeping the cursor in view")
+
+	view.SetMaxDisplayedItems(4)
+	assert.Equal(t, 4, view.NumDisplayed(), "Expected number of displayed items to be 4")
+	assert.Equal(t, []string{"item2", "item3", "item4", "item5"}, view.View(), "Expected view to move by 1 to keep the cursor in view, without going over the end")
+}
+
+func TestSetCursor(t *testing.T) {
+	items := []string{"item1", "item2", "item3"}
+	view := list.NewSliceView(items)
+
+	view.SetCursor(2)
+	assert.Equal(t, 2, view.Cursor(), "Expected cursor to be set to 2")
+	assert.Equal(t, "item3", view.Choice(), "Expected choice to be 'item3'")
+}
+
+func TestView(t *testing.T) {
+	items := []string{"item1", "item2", "item3", "item4", "item5"}
+	view := list.NewSliceView(items)
+
+	view.SetMaxDisplayedItems(3)
+	assert.Equal(t, []string{"item1", "item2", "item3"}, view.View(), "Expected view to display the first 3 items")
+
+	view.SetCursor(4)
+	assert.Equal(t, "item5", view.Choice(), "Expected choice to be 'item5'")
+	assert.Equal(t, []string{"item3", "item4", "item5"}, view.View(), "Expected view to update to show last 3 items")
+}

--- a/pkg/view/tui/components/listprompt/listprompt.go
+++ b/pkg/view/tui/components/listprompt/listprompt.go
@@ -17,6 +17,8 @@
 package listprompt
 
 import (
+	"strings"
+
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -38,10 +40,8 @@ func (m ListPrompt) Init() tea.Cmd {
 	return nil
 }
 
-func (m ListPrompt) UpdateItems(items []list.ListItem) ListPrompt {
-	m.listInput = m.listInput.UpdateItems(items)
-
-	return m
+func (m ListPrompt) IsPaginationVisible() bool {
+	return m.listInput.IsPaginationVisible()
 }
 
 func (m ListPrompt) UpdateListPrompt(msg tea.Msg) (ListPrompt, tea.Cmd) {
@@ -76,6 +76,14 @@ func (m *ListPrompt) SetChoice(choice string) {
 	m.listInput.SetChoice(choice)
 }
 
+func (m *ListPrompt) SetMaxDisplayedItems(maxDisplayedItems int) {
+	m.listInput.SetMaxDisplayedItems(maxDisplayedItems)
+}
+
+func (m *ListPrompt) SetMinimized(minimized bool) {
+	m.listInput.SetMinimized(minimized)
+}
+
 var (
 	promptStyle      = lipgloss.NewStyle().MarginLeft(2)
 	inputStyle       = lipgloss.NewStyle().MarginLeft(8)
@@ -83,7 +91,7 @@ var (
 )
 
 func (m ListPrompt) View() string {
-	listView := view.New()
+	listView := view.New(view.WithStyle(lipgloss.NewStyle()))
 
 	// render the list header
 	listView.Add(fragments.Tag(m.Tag))
@@ -97,7 +105,7 @@ func (m ListPrompt) View() string {
 		listView.Addln(m.Choice()).WithStyle(historyTextStyle)
 	}
 
-	return listView.Render()
+	return strings.TrimSuffix(listView.Render(), "\n")
 }
 
 type ListPromptArgs struct {

--- a/pkg/view/tui/components/view/view.go
+++ b/pkg/view/tui/components/view/view.go
@@ -64,6 +64,14 @@ func (v *View) Render() string {
 	builder := strings.Builder{}
 
 	for _, fragment := range v.fragments {
+		if fragment == nil {
+			continue
+		}
+
+		if fragment.content == "" {
+			continue
+		}
+
 		builder.WriteString(fragment.Render())
 	}
 


### PR DESCRIPTION
Lists now paginate and/or shrink based on the available height in the terminal