### PR TITLE
fix: expose aws-cfg-ephemeral for pulumi and terraform provider

### DIFF
--- a/pkg/project/stack/aws.config.yaml
+++ b/pkg/project/stack/aws.config.yaml
@@ -38,14 +38,19 @@ region:
 #     telemetry: 0
 #     # configure functions to deploy to AWS lambda
 #     lambda: # Available since v0.26.0
-#       # set 128MB of RAM
+#       # set the memory in MB
 #       # See lambda configuration docs here:
 #       # https://docs.aws.amazon.com/lambda/latest/dg/configuration-function-common.html#configuration-memory-console
 #       memory: 128
-#       # set a timeout of 15 seconds
+#       # set a timeout in seconds
 #       # See lambda timeout values here:
 #       # https://docs.aws.amazon.com/lambda/latest/dg/configuration-function-common.html#configuration-timeout-console
 #       timeout: 15
+#       # set the amount of ephemeral-storage in MB
+#       # For info on ephemeral-storage for AWS Lambda see:
+#       # https://docs.aws.amazon.com/lambda/latest/dg/configuration-ephemeral-storage.html
+#       # Available Since nitric/aws@1.14.2
+#       ephemeral-storage: 512
 #       # set a provisioned concurrency value
 #       # For info on provisioned concurrency for AWS Lambda see:
 #       # https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html

--- a/pkg/project/stack/awstf.config.yaml
+++ b/pkg/project/stack/awstf.config.yaml
@@ -28,17 +28,19 @@ region:
 #     telemetry: 0
 #     # configure functions to deploy to AWS lambda
 #     lambda: # Available since v0.26.0
-#       # set 128MB of RAM
+#       # set the memory in MB
 #       # See lambda configuration docs here:
 #       # https://docs.aws.amazon.com/lambda/latest/dg/configuration-function-common.html#configuration-memory-console
 #       memory: 128
-#       # set a timeout of 15 seconds
+#       # set a timeout in seconds
 #       # See lambda timeout values here:
 #       # https://docs.aws.amazon.com/lambda/latest/dg/configuration-function-common.html#configuration-timeout-console
 #       timeout: 15
-#       # set a provisioned concurrency value
-#       # For info on provisioned concurrency for AWS Lambda see:
-#       # https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html
+#       # set the amount of ephemeral-storage in MB
+#       # For info on ephemeral-storage for AWS Lambda see:
+#       # https://docs.aws.amazon.com/lambda/latest/dg/configuration-ephemeral-storage.html
+#       # Available Since nitric/aws@1.14.2
+#       ephemeral-storage: 512
 #   # Additional deployment types
 #   # You can target these types by setting a `type` in your project configuration
 #   big-service:


### PR DESCRIPTION
Update the config for ephemeral storage setting.

requires https://github.com/nitrictech/nitric/pull/687 to be merged first