### PR TITLE
fix: refresh secrets in dashboard

### DIFF
--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -282,6 +282,7 @@ func (d *Dashboard) updateResources(lrs resources.LocalResourcesState) {
 	d.stores = []*KeyValueSpec{}
 	d.queues = []*QueueSpec{}
 	d.apiSecurityDefinitions = map[string]map[string]*resourcespb.ApiSecurityDefinitionResource{}
+	d.secrets = []*SecretSpec{}
 
 	d.policies = map[string]PolicySpec{}
 


### PR DESCRIPTION
During nitric start. If a secret is changed or removed, it stays in the dashboard until re-run.