### PR TITLE
fix: ensure api history is unique across apis

### DIFF
--- a/pkg/dashboard/frontend/src/components/apis/APIExplorer.tsx
+++ b/pkg/dashboard/frontend/src/components/apis/APIExplorer.tsx
@@ -757,6 +757,8 @@ const APIExplorer = () => {
                   path: selectedApiEndpoint.path,
                   method: request.method,
                 }}
+                api={selectedApiEndpoint.api}
+                apiAddress={apiAddress || 'localhost:4001'}
               />
             </SectionCard>
           </div>

--- a/pkg/dashboard/handlers.go
+++ b/pkg/dashboard/handlers.go
@@ -517,7 +517,7 @@ func (d *Dashboard) handleApiHistory(state apis.ApiRequestState) {
 		Time:       time.Now().UnixMilli(),
 		RecordType: API,
 		Event: ApiHistoryItem{
-			Api: d.gatewayService.GetApiAddresses()[state.Api],
+			Api: state.Api,
 			Request: &RequestHistory{
 				Method:      string(state.ReqCtx.Request.Header.Method()),
 				Path:        string(state.ReqCtx.URI().PathOriginal()),


### PR DESCRIPTION
fixes #806 

This is backward compatible so users don't lose their current API history from the list.