### PR TITLE
feat: use latest provider version in stack new and stack up commands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,10 +66,11 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
-		update.FetchLatestVersion()
+		update.FetchLatestCLIVersion()
+		update.FetchLatestProviderVersion()
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
-		update.PrintOutdatedWarning()
+		update.PrintOutdatedCLIWarning()
 		// an unstyled \n is always needed at the end of the view to ensure the last line renders
 		fmt.Println()
 	},

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -36,6 +36,7 @@ import (
 	"github.com/nitrictech/cli/pkg/project/stack"
 	"github.com/nitrictech/cli/pkg/provider"
 	"github.com/nitrictech/cli/pkg/provider/pulumi"
+	"github.com/nitrictech/cli/pkg/update"
 	"github.com/nitrictech/cli/pkg/view/tui"
 	"github.com/nitrictech/cli/pkg/view/tui/commands/build"
 	stack_down "github.com/nitrictech/cli/pkg/view/tui/commands/stack/down"
@@ -165,6 +166,9 @@ var stackUpdateCmd = &cobra.Command{
 		if !isNonInteractive() {
 			_ = pulumi.EnsurePulumiPassphrase(fs)
 		}
+
+		// print provider version check
+		update.PrintOutdatedProviderWarning(stackConfig.Provider)
 
 		proj, err := project.FromFile(fs, "")
 		tui.CheckErr(err)

--- a/go.mod
+++ b/go.mod
@@ -35,10 +35,12 @@ require (
 )
 
 require (
+	github.com/Masterminds/semver/v3 v3.3.0
 	github.com/asaskevich/EventBus v0.0.0-20200907212545-49d423059eef
 	github.com/charmbracelet/bubbles v0.16.1
 	github.com/charmbracelet/bubbletea v0.24.2
 	github.com/charmbracelet/lipgloss v0.8.0
+	github.com/ettle/strcase v0.2.0
 	github.com/fasthttp/websocket v1.5.3
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e
@@ -78,7 +80,6 @@ require (
 	github.com/DataDog/zstd v1.5.5 // indirect
 	github.com/Djarvur/go-err113 v0.1.0 // indirect
 	github.com/GaijinEntertainment/go-exhaustruct/v3 v3.3.0 // indirect
-	github.com/Masterminds/semver/v3 v3.3.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/OpenPeeDeeP/depguard/v2 v2.2.0 // indirect
 	github.com/Sereal/Sereal v0.0.0-20221130110801-16a4f76670cd // indirect
@@ -114,7 +115,6 @@ require (
 	github.com/denis-tingaikin/go-header v0.5.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/ettle/strcase v0.2.0 // indirect
 	github.com/fatih/color v1.17.0 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
@@ -161,7 +161,6 @@ require (
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
-	github.com/iancoleman/strcase v0.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/invopop/yaml v0.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -433,8 +433,6 @@ github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUq
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
-github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
-github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -797,7 +797,7 @@ func handleResponseWriter(w http.ResponseWriter, data []byte) {
 
 func (d *Dashboard) sendStackUpdate() error {
 	currentVersion := strings.TrimPrefix(version.Version, "v")
-	latestVersion := update.FetchLatestVersion()
+	latestVersion := update.FetchLatestCLIVersion()
 
 	services, err := d.getServices()
 	if err != nil {

--- a/pkg/project/stack/aws.config.yaml
+++ b/pkg/project/stack/aws.config.yaml
@@ -1,5 +1,5 @@
 # The nitric provider to use
-provider: nitric/aws@1.14.0
+provider: nitric/aws@{{.Version}}
 # The target aws region to deploy to
 # See available regions:
 # https://docs.aws.amazon.com/general/latest/gr/lambda-service.html

--- a/pkg/project/stack/awstf.config.yaml
+++ b/pkg/project/stack/awstf.config.yaml
@@ -1,5 +1,5 @@
 # The nitric provider to use
-provider: nitric/awstf@1.14.0
+provider: nitric/awstf@{{.Version}}
 # The target aws region to deploy to
 # See available regions:
 # https://docs.aws.amazon.com/general/latest/gr/lambda-service.html

--- a/pkg/project/stack/azure.config.yaml
+++ b/pkg/project/stack/azure.config.yaml
@@ -1,7 +1,7 @@
 # The provider to use and it's published version
 # See releases:
 # https://github.com/nitrictech/nitric/tags
-provider: nitric/azure@1.14.0
+provider: nitric/azure@{{.Version}}
 # The target Azure region to deploy to
 # See available regions:
 # https://azure.microsoft.com/en-us/explore/global-infrastructure/products-by-region/?products=container-apps

--- a/pkg/project/stack/gcp.config.yaml
+++ b/pkg/project/stack/gcp.config.yaml
@@ -1,7 +1,7 @@
 # The provider to use and it's published version
 # See releases:
 # https://github.com/nitrictech/nitric/tags
-provider: nitric/gcp@1.14.0
+provider: nitric/gcp@{{.Version}}
 
 # The target GCP region to deploy to
 # See available regions:

--- a/pkg/project/stack/gcptf.config.yaml
+++ b/pkg/project/stack/gcptf.config.yaml
@@ -1,7 +1,7 @@
 # The provider to use and it's published version
 # See releases:
 # https://github.com/nitrictech/nitric/tags
-provider: nitric/gcptf@1.14.0
+provider: nitric/gcptf@{{.Version}}
 
 # The target GCP region to deploy to
 # See available regions:

--- a/pkg/project/stack/stack.go
+++ b/pkg/project/stack/stack.go
@@ -87,6 +87,7 @@ func NewStackFile(fs afero.Fs, providerName string, stackName string, dir string
 	}
 
 	var result bytes.Buffer
+
 	err = tmpl.Execute(&result, map[string]string{
 		"Version": latestVersion,
 	})

--- a/pkg/project/stack/stack.go
+++ b/pkg/project/stack/stack.go
@@ -17,14 +17,18 @@
 package stack
 
 import (
+	"bytes"
 	_ "embed"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
+	"text/template"
 
 	"github.com/spf13/afero"
 	"gopkg.in/yaml.v3"
+
+	"github.com/nitrictech/cli/pkg/update"
 )
 
 type StackConfig[T any] struct {
@@ -59,20 +63,38 @@ func NewStackFile(fs afero.Fs, providerName string, stackName string, dir string
 		dir = "./"
 	}
 
-	var template string = ""
+	latestVersion := update.FetchLatestProviderVersion()
+
+	var templateStr string = ""
 
 	switch providerName {
 	case "aws":
-		template = awsConfigTemplate
+		templateStr = awsConfigTemplate
 	case "gcp":
-		template = gcpConfigTemplate
+		templateStr = gcpConfigTemplate
 	case "azure":
-		template = azureConfigTemplate
+		templateStr = azureConfigTemplate
 	case "aws-tf":
-		template = awsTfConfigTemplate
+		templateStr = awsTfConfigTemplate
 	case "gcp-tf":
-		template = gcpTfConfigTemplate
+		templateStr = gcpTfConfigTemplate
 	}
+
+	// Parse and execute the template with the version injected
+	tmpl, err := template.New("config").Parse(templateStr)
+	if err != nil {
+		return "", err
+	}
+
+	var result bytes.Buffer
+	err = tmpl.Execute(&result, map[string]string{
+		"Version": latestVersion,
+	})
+	if err != nil {
+		return "", fmt.Errorf("unable to execute provider config template: %w", err)
+	}
+
+	templateStr = result.String()
 
 	fileName := StackFileName(stackName)
 
@@ -83,7 +105,7 @@ func NewStackFile(fs afero.Fs, providerName string, stackName string, dir string
 	stackFilePath := filepath.Join(dir, fileName)
 	relativePath, _ := filepath.Rel(".", stackFilePath)
 
-	return fmt.Sprintf(".%s%s", string(os.PathSeparator), relativePath), afero.WriteFile(fs, stackFilePath, []byte(template), os.ModePerm)
+	return fmt.Sprintf(".%s%s", string(os.PathSeparator), relativePath), afero.WriteFile(fs, stackFilePath, []byte(templateStr), os.ModePerm)
 }
 
 // StackFileName returns the stack file name for a given stack name

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -51,11 +51,7 @@ func PrintOutdatedCLIWarning() {
 		return
 	}
 
-	updateAvailable, err := isOutdated(currentVersion, latestVersion)
-	if err != nil {
-		tui.Error.Println(fmt.Sprintf("Failed to check for updates for CLI: %s", err))
-		return
-	}
+	updateAvailable := isOutdated(currentVersion, latestVersion)
 
 	if updateAvailable {
 		msg := fmt.Sprintf(`A new version of Nitric is available. To upgrade from version '%s' to '%s'`, currentVersion, latestVersion)
@@ -79,11 +75,7 @@ func PrintOutdatedProviderWarning(providerName string) {
 		return
 	}
 
-	updateAvailable, err := isOutdated(currentVersion, latestVersion)
-	if err != nil {
-		tui.Error.Println(fmt.Sprintf("Failed to check for updates for %s: %s", providerName, err))
-		return
-	}
+	updateAvailable := isOutdated(currentVersion, latestVersion)
 
 	if updateAvailable {
 		tui.Info.Println(fmt.Sprintf(`Update available for %s: '%s' → '%s'.`, providerName, currentVersion, latestVersion))
@@ -164,23 +156,21 @@ func updateFile(latestVersion string, cachePath string) error {
 	return nil
 }
 
-func isOutdated(currentVersion string, latestVersion string) (bool, error) {
+func isOutdated(currentVersion string, latestVersion string) bool {
 	// if current version is latest, no need to update
 	if currentVersion == "latest" {
-		return false, nil
+		return false
 	}
 
 	latestVer, err := semver.NewVersion(latestVersion)
 	if err != nil {
-		tui.Error.Println(fmt.Sprintf("Failed to parse latest version: %s", latestVersion))
-		return false, err
+		return false
 	}
 
 	currentVer, err := semver.NewVersion(currentVersion)
 	if err != nil {
-		tui.Error.Println(fmt.Sprintf("Failed to parse current version: %s", currentVersion))
-		return false, err
+		return false
 	}
 
-	return currentVer.LessThan(latestVer), nil
+	return currentVer.LessThan(latestVer)
 }

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -58,6 +58,24 @@ func PrintOutdatedCLIWarning() {
 	}
 }
 
+func PrintOutdatedProviderWarning(providerName string) {
+	latestVersion := FetchLatestProviderVersion()
+
+	var currentVersion string
+
+	providerParts := strings.SplitN(providerName, "@", 2)
+	if len(providerParts) == 2 {
+		providerName = providerParts[0]
+		currentVersion = providerParts[1]
+	}
+
+	if currentVersion < latestVersion {
+		tui.Info.Println(fmt.Sprintf(`Update available for %s: '%s' → '%s'.`, providerName, currentVersion, latestVersion))
+		tui.Info.Println(fmt.Sprintf("Visit https://github.com/nitrictech/nitric/releases/tag/v%s for release notes.", latestVersion))
+		fmt.Println("")
+	}
+}
+
 func fetchLatestVersion(repo string, cachePath string) string {
 	latestVersionContents, err := os.ReadFile(cachePath)
 	latestVersion := string(latestVersionContents)

--- a/pkg/view/tui/printer.go
+++ b/pkg/view/tui/printer.go
@@ -32,6 +32,9 @@ var (
 	Error = TagPrinter{
 		Prefix: addPrefix("error", Colors.White, Colors.Red),
 	}
+	Info = TagPrinter{
+		Prefix: addPrefix("info", Colors.White, Colors.TextMuted),
+	}
 	Warning = TagPrinter{
 		Prefix: addPrefix("warning", Colors.Black, Colors.Yellow),
 	}


### PR DESCRIPTION
Closes #813 

- fetch and cache latest provider version
- use the latest version in `stack new`
- show message if a version is outdated during `stack up`