### PR TITLE
fix: correct worker count for services

### DIFF
--- a/pkg/collector/service.go
+++ b/pkg/collector/service.go
@@ -108,9 +108,15 @@ func (s *ServiceRequirements) HasDatabases() bool {
 func (s *ServiceRequirements) WorkerCount() int {
 	workerCount := len(lo.Values(s.routes)) +
 		len(s.listeners) +
-		len(s.schedules) +
-		len(lo.Values(s.subscriptions)) +
-		len(lo.Values(s.websockets))
+		len(s.schedules)
+
+	for _, sub := range s.subscriptions {
+		workerCount += len(sub)
+	}
+
+	for _, ws := range s.websockets {
+		workerCount += len(ws)
+	}
 
 	if s.proxy != nil {
 		workerCount++


### PR DESCRIPTION
Issue with counts for workers for subscriptions and websockets was causing the minimum worker count to be the number of unique websockets or topics for a service and not the number of actual worker registrations.