### PR TITLE
fix: include error details if a docker connection fails

### DIFF
--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -62,7 +62,7 @@ func VerifyDockerIsAvailable() error {
 
 	// Perform a Docker operation to verify availability
 	if _, pingErr := cli.Ping(context.Background()); pingErr != nil {
-		return fmt.Errorf("Docker daemon is not running, please start the docker daemon and try again")
+		return fmt.Errorf("failed to connect to Docker: %w", pingErr)
 	}
 
 	return nil


### PR DESCRIPTION
Updates the output to include the original error details:

![example output](https://github.com/user-attachments/assets/8a7fac44-7252-4fa8-bca1-861547b61575)
