### PR TITLE
fix: implement api details method for local

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -256,7 +256,6 @@ func New(projectName string, opts LocalCloudOptions) (*LocalCloud, error) {
 	}
 
 	localResources := resources.NewLocalResourcesService()
-	localApis := apis.NewLocalApiGatewayService()
 	localBatch := batch.NewLocalBatchService()
 	localSchedules := schedules.NewLocalSchedulesService(localResources.LogServiceError)
 	localHttpProxy := http.NewLocalHttpProxyService()
@@ -270,6 +269,8 @@ func New(projectName string, opts LocalCloudOptions) (*LocalCloud, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	localApis := apis.NewLocalApiGatewayService(localGateway.GetApiAddress)
 
 	localSecrets, err := secrets.NewSecretService()
 	if err != nil {

--- a/pkg/cloud/gateway/gateway.go
+++ b/pkg/cloud/gateway/gateway.go
@@ -144,6 +144,19 @@ func (s *LocalGatewayService) GetApiAddresses() map[string]string {
 	return addresses
 }
 
+func (s *LocalGatewayService) GetApiAddress(apiName string) string {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	addresses := s.GetApiAddresses()
+
+	if address, ok := addresses[apiName]; ok {
+		return address
+	}
+
+	return ""
+}
+
 func (s *LocalGatewayService) GetHttpWorkerAddresses() map[string]string {
 	s.lock.RLock()
 	defer s.lock.RUnlock()


### PR DESCRIPTION
fixes unimplemented error on `api.url` calls.