### PR TITLE
fix(dash): show sdk permission names for buckets and kv in diagram

### DIFF
--- a/pkg/dashboard/frontend/src/lib/constants.ts
+++ b/pkg/dashboard/frontend/src/lib/constants.ts
@@ -74,3 +74,11 @@ GROUP BY
     tbl.quoted_name,
     tbl.is_table;
 `
+// translate permission names to sdk permission names
+export const PERMISSION_TO_SDK_LABELS: Record<string, string> = {
+  BucketFileGet: 'Read',
+  BucketFileList: 'Read',
+  BucketFilePut: 'Write',
+  KeyValueStoreRead: 'Set',
+  KeyValueStoreWrite: 'Get',
+}

--- a/pkg/dashboard/frontend/src/lib/utils/generate-architecture-data.ts
+++ b/pkg/dashboard/frontend/src/lib/utils/generate-architecture-data.ts
@@ -62,6 +62,7 @@ import {
   BatchNode,
   type BatchNodeData,
 } from '@/components/architecture/nodes/BatchNode'
+import { PERMISSION_TO_SDK_LABELS } from '../constants'
 
 export const nodeTypes = {
   api: APINode,
@@ -196,7 +197,7 @@ const actionVerbs = [
 function verbFromNitricAction(action: string) {
   for (const verb of actionVerbs) {
     if (action.endsWith(verb)) {
-      return verb
+      return PERMISSION_TO_SDK_LABELS[action] || verb
     }
   }
 
@@ -538,7 +539,7 @@ export function generateArchitectureData(data: WebSocketResponse): {
           type: MarkerType.ArrowClosed,
           orient: 'auto-start-reverse',
         },
-        label: policy.actions.map(verbFromNitricAction).join(', '),
+        label: unique(policy.actions.map(verbFromNitricAction)).join(', '),
       } as Edge
     }),
   )


### PR DESCRIPTION
Fixes #831 