### PR TITLE
fix: handle migration path conflicts for identical database declarations

### DIFF
--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -115,6 +115,9 @@ var specCmd = &cobra.Command{
 			envVariables = map[string]string{}
 		}
 
+		spec, err := collector.ServiceRequirementsToSpec(proj.Name, envVariables, serviceRequirements, batchRequirements)
+		tui.CheckErr(err)
+
 		migrationImageContexts, err := collector.GetMigrationImageBuildContexts(serviceRequirements, batchRequirements, fs)
 		tui.CheckErr(err)
 		// Build images from contexts and provide updates on the builds
@@ -146,9 +149,6 @@ var specCmd = &cobra.Command{
 		if outputFile == "" {
 			outputFile = "./nitric-spec.json"
 		}
-
-		spec, err := collector.ServiceRequirementsToSpec(proj.Name, envVariables, serviceRequirements, batchRequirements)
-		tui.CheckErr(err)
 
 		marshaler := protojson.MarshalOptions{
 			Multiline: true,

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -240,6 +240,9 @@ var stackUpdateCmd = &cobra.Command{
 			envVariables["NITRIC_BETA_PROVIDERS"] = "true"
 		}
 
+		spec, err := collector.ServiceRequirementsToSpec(proj.Name, envVariables, serviceRequirements, batchRequirements)
+		tui.CheckErr(err)
+
 		migrationImageContexts, err := collector.GetMigrationImageBuildContexts(serviceRequirements, batchRequirements, fs)
 		tui.CheckErr(err)
 		// Build images from contexts and provide updates on the builds
@@ -266,9 +269,6 @@ var stackUpdateCmd = &cobra.Command{
 				}
 			}
 		}
-
-		spec, err := collector.ServiceRequirementsToSpec(proj.Name, envVariables, serviceRequirements, batchRequirements)
-		tui.CheckErr(err)
 
 		providerStdout := make(chan string)
 

--- a/pkg/collector/spec.go
+++ b/pkg/collector/spec.go
@@ -275,6 +275,10 @@ func checkConflictingMigrations(allDatabases []map[string]*resourcespb.SqlDataba
 	for _, dbs := range allDatabases {
 		for databaseName, dbConfig := range resource {
 			if existing, exists := dbs[databaseName]; exists {
+				if dbConfig.Migrations == nil {
+					continue
+				}
+
 				if existing.Migrations.GetMigrationsPath() != dbConfig.Migrations.GetMigrationsPath() {
 					return fmt.Errorf("database '%s' has conflicting migrations paths; they must be identical", databaseName)
 				}


### PR DESCRIPTION
When multiple database declarations occur, check if the migrations path conficts and error with action.