### PR TITLE
fix: allow no services

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -69,10 +69,6 @@ func (p *Project) GetBatchServices() []Batch {
 func (p *Project) BuildBatches(fs afero.Fs, useBuilder bool) (chan ServiceBuildUpdate, error) {
 	updatesChan := make(chan ServiceBuildUpdate)
 
-	if len(p.services) == 0 {
-		return nil, fmt.Errorf("no services found in project, nothing to build. This may indicate misconfigured `match` patterns in your nitric.yaml file")
-	}
-
 	maxConcurrentBuilds := make(chan struct{}, min(goruntime.NumCPU(), goruntime.GOMAXPROCS(0)))
 
 	waitGroup := sync.WaitGroup{}
@@ -129,10 +125,6 @@ func (p *Project) BuildBatches(fs afero.Fs, useBuilder bool) (chan ServiceBuildU
 // BuildServices - Builds all the services in the project
 func (p *Project) BuildServices(fs afero.Fs, useBuilder bool) (chan ServiceBuildUpdate, error) {
 	updatesChan := make(chan ServiceBuildUpdate)
-
-	if len(p.services) == 0 {
-		return nil, fmt.Errorf("no services found in project, nothing to build. This may indicate misconfigured `match` patterns in your nitric.yaml file")
-	}
 
 	maxConcurrentBuilds := make(chan struct{}, min(goruntime.NumCPU(), goruntime.GOMAXPROCS(0)))
 
@@ -571,6 +563,10 @@ func fromProjectConfiguration(projectConfig *ProjectConfiguration, localConfig *
 		files, err := afero.Glob(fs, serviceMatch)
 		if err != nil {
 			return nil, fmt.Errorf("unable to match service files for pattern %s: %w", serviceMatch, err)
+		}
+
+		if len(files) == 0 {
+			return nil, fmt.Errorf("unable to match service files for pattern %s. This may indicate misconfigured `match` patterns in your nitric.yaml file", serviceMatch)
 		}
 
 		for _, f := range files {


### PR DESCRIPTION
With an invalid stack file with matches not pointing to any files:
```yaml
services:
    match: invalid-path/*.dart
    start: dart run --observe $SERVICE_PATH
    runtime: dart
batch-services:
    match: invalid-path/*.dart
    start: dart run --observe $SERVICE_PATH
    runtime: dart
```

`nitric run`
Old:
```
Local cloud started successfully
 error  no services found in project, nothing to build. This may indicate misconfigured `match` patterns in your nitric.yaml file
```
New:
```
error  unable to match service files for pattern fun/*.dart. This may indicate misconfigured `match` patterns in your nitric.yaml file
```

`nitric start`
Old: Default no services tui (see screenshot)
New:
```
error  unable to match service files for pattern fun/*.dart. This may indicate misconfigured `match` patterns in your nitric.yaml file
```

`nitric spec`
Old:  
```
error  no services found in project, nothing to build. This may indicate misconfigured `match` patterns in your nitric.yaml file
```
New:
```
error  unable to match service files for pattern fun/*.dart. This may indicate misconfigured `match` patterns in your nitric.yaml file
```

`nitric up`
Old:  
```
error  no services found in project, nothing to build. This may indicate misconfigured `match` patterns in your nitric.yaml file
```
New:
```
error  unable to match service files for pattern fun/*.dart. This may indicate misconfigured `match` patterns in your nitric.yaml file
```

With a valid stack file that contains no matches:
```yaml
services: []
batch-services: []
```

`nitric run`
Old:
```
Local cloud started successfully
 error  no services found in project, nothing to build. This may indicate misconfigured `match` patterns in your nitric.yaml file
```
New: Default no services tui (see screenshot)

`nitric start`
Old and New: Default no services tui (see screenshot)

`nitric spec`
Old:  
```
error  no services found in project, nothing to build. This may indicate misconfigured `match` patterns in your nitric.yaml file
```
New:
```
build   Building Services                                        
Successfully outputted deployment spec to ./nitric-spec.json
```

`nitric up`
Old: 
```
error  no services found in project, nothing to build. This may indicate misconfigured `match` patterns in your nitric.yaml file
```
New: Deploys

![Screenshot 2024-12-30 at 10 14 22 AM](https://github.com/user-attachments/assets/a9abe8df-e40d-4ea7-abce-51845b37cfc0)