### PR TITLE
fix: update path matching regex to be stricter to ensure no history leakage

### DIFF
--- a/pkg/dashboard/frontend/src/components/apis/APIHistory.tsx
+++ b/pkg/dashboard/frontend/src/components/apis/APIHistory.tsx
@@ -27,7 +27,7 @@ const checkEquivalentPaths = (matcher: string, path: string): boolean => {
     return matcherBase === pathBase
   }
 
-  const regex = new RegExp(`^${matcherBase.replace(/{[^/]+}/, '[^/]+')}$`)
+  const regex = new RegExp(`^${matcherBase.replace(/{[^/]+}/g, '[^/]+')}$`)
 
   return regex.test(pathBase)
 }

--- a/pkg/dashboard/frontend/src/components/apis/APIHistory.tsx
+++ b/pkg/dashboard/frontend/src/components/apis/APIHistory.tsx
@@ -18,13 +18,18 @@ interface Props {
 }
 
 const checkEquivalentPaths = (matcher: string, path: string): boolean => {
-  // If the paths are equal regardless of query params
-  if (path.split('?').length > 1 && matcher.split('?').length > 1) {
-    return path.split('?')[0] === matcher.split('?')[0]
+  // Split both the matcher and path by "?" to separate query parameters
+  const [matcherBase] = matcher.split('?')
+  const [pathBase] = path.split('?')
+
+  // If both have query parameters, compare only the base paths
+  if (matcher.includes('?') && path.includes('?')) {
+    return matcherBase === pathBase
   }
 
-  const regex = matcher.replace(/{(.*)}/, '(.*)')
-  return path.match(regex) !== null
+  const regex = new RegExp(`^${matcherBase.replace(/{[^/]+}/, '[^/]+')}$`)
+
+  return regex.test(pathBase)
 }
 
 const APIHistory: React.FC<Props> = ({


### PR DESCRIPTION
Tested using the following paths:
```
/
/user
/user/{name}
/user/{name}/images
/user/{name}/images/{id}
```

Correctly associated each history path to belong to the correct API route. For reference: the regex looks like `^\/user\/[^/]+$` for a path to match for `/user/{name}`.

