### PR TITLE
move json parsing into format to avoid error on invalid json response

### DIFF
--- a/pkg/dashboard/frontend/src/lib/utils/generate-response.ts
+++ b/pkg/dashboard/frontend/src/lib/utils/generate-response.ts
@@ -6,7 +6,7 @@ export const generateResponse = async (res: Response, startTime: number) => {
   let data
 
   if (contentType === 'application/json') {
-    data = formatJSON(await res.json())
+    data = formatJSON(await res.text())
   } else if (
     contentType?.startsWith('image/') ||
     contentType?.startsWith('video/') ||


### PR DESCRIPTION
When a response in the dashboard had invalid json, the response content component would have a spinner running indefinitely. This fix moves the json parsing from the response body and into the `formatJson` method. If it is invalid or bytes, it will produce the result in the content box directly rather than an unexpected error.