### PR TITLE
fix(dash): increase dashboard header size limit

### DIFF
--- a/pkg/cloud/gateway/gateway.go
+++ b/pkg/cloud/gateway/gateway.go
@@ -650,7 +650,7 @@ func (s *LocalGatewayService) createApiServers() error {
 			ReadTimeout:     time.Second * 1,
 			IdleTimeout:     time.Second * 1,
 			CloseOnShutdown: true,
-			ReadBufferSize:  8192,
+			ReadBufferSize:  64 * 1024, // Set to 64 KB to handle large headers
 			Handler:         s.handleApiHttpRequest(apiName),
 			Logger:          log.New(s.logWriter, fmt.Sprintf("%s: ", lis.Addr().String()), 0),
 		}


### PR DESCRIPTION
Reduces the occurrence of 431 Request Header Fields Too Large errors. Increased to 64KB.