### PR TITLE
fix: removes beta providers preview flag

### DIFF
--- a/pkg/view/tui/commands/stack/new/stack_new.go
+++ b/pkg/view/tui/commands/stack/new/stack_new.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/spinner"
@@ -29,7 +28,6 @@ import (
 	"github.com/samber/lo"
 	"github.com/spf13/afero"
 
-	"github.com/nitrictech/cli/pkg/preview"
 	"github.com/nitrictech/cli/pkg/project"
 	"github.com/nitrictech/cli/pkg/project/stack"
 	clitui "github.com/nitrictech/cli/pkg/view/tui"
@@ -237,16 +235,6 @@ func (m Model) View() string {
 
 		indent.Addln("Check the file for any additional configuration required.")
 		indent.Break()
-
-		provName := providerLabelToValue(m.ProviderName())
-
-		if (provName == "aws-tf" || provName == "gcp-tf") && !slices.Contains(m.projectConfig.Preview, preview.Feature_BetaProviders) {
-			indent.Add("Add ")
-			indent.Add("beta-providers").WithStyle(highlightStyle)
-			indent.Add(" to your nitric.yaml preview config to enable preview provider support.")
-			indent.Break()
-			indent.Break()
-		}
 
 		indent.Add("Then deploy your stack using ")
 		indent.Addln("nitric up").WithStyle(highlightStyle)


### PR DESCRIPTION
merge after: https://github.com/nitrictech/nitric/pull/771

Just removes the message after stack new, leaving the CLI backward compat provider < v1.23.1