### PR TITLE
fix: correctly serves websites on start/run

### DIFF
--- a/.github/workflows/dashboard-run-test.yaml
+++ b/.github/workflows/dashboard-run-test.yaml
@@ -50,6 +50,8 @@ jobs:
 
       - name: Run Tests
         uses: cypress-io/github-action@v5
+        env:
+          CYPRESS_NITRIC_TEST_TYPE: "run"
         with:
           install: false
           wait-on: "http://localhost:49152"

--- a/.github/workflows/dashboard-start-test.yaml
+++ b/.github/workflows/dashboard-start-test.yaml
@@ -64,6 +64,8 @@ jobs:
           wait-on-timeout: 180
           working-directory: cli/pkg/dashboard/frontend
           browser: chrome
+        env:
+          CYPRESS_NITRIC_TEST_TYPE: "start"
 
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/pkg/cloud/websites/websites.go
+++ b/pkg/cloud/websites/websites.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 
@@ -224,9 +225,13 @@ func (l *LocalWebsiteService) startServer(server *http.Server, errChan chan erro
 
 // Start - Start the local website service
 func (l *LocalWebsiteService) Start(websites []Website) error {
-	var errChan = make(chan error, 1)
+	errChan := make(chan error, 1)
 
-	var startPort = 5000
+	startPort := 5000
+
+	slices.SortFunc(websites, func(a, b Website) int {
+		return strings.Compare(a.BasePath, b.BasePath)
+	})
 
 	if l.isStartCmd {
 		// In start mode, create individual servers for each website

--- a/pkg/cloud/websites/websites.go
+++ b/pkg/cloud/websites/websites.go
@@ -56,7 +56,6 @@ type (
 type LocalWebsiteService struct {
 	websiteRegLock sync.RWMutex
 	state          State
-	port           int
 	getApiAddress  GetApiAddress
 	isStartCmd     bool
 
@@ -95,7 +94,6 @@ func (l *LocalWebsiteService) register(website Website, port int) {
 
 type staticSiteHandler struct {
 	website    *Website
-	port       int
 	devURL     string
 	isStartCmd bool
 	server     *http.Server
@@ -227,6 +225,7 @@ func (l *LocalWebsiteService) startServer(server *http.Server, errChan chan erro
 // Start - Start the local website service
 func (l *LocalWebsiteService) Start(websites []Website) error {
 	var errChan = make(chan error, 1)
+
 	var startPort = 5000
 
 	if l.isStartCmd {
@@ -251,7 +250,6 @@ func (l *LocalWebsiteService) Start(websites []Website) error {
 			// Create the SPA handler for this website
 			spa := staticSiteHandler{
 				website:    website,
-				port:       port,
 				devURL:     website.DevURL,
 				isStartCmd: l.isStartCmd,
 			}
@@ -291,7 +289,6 @@ func (l *LocalWebsiteService) Start(websites []Website) error {
 			website := &websites[i]
 			spa := staticSiteHandler{
 				website:    website,
-				port:       port,
 				devURL:     website.DevURL,
 				isStartCmd: l.isStartCmd,
 			}

--- a/pkg/dashboard/frontend/cypress/e2e/websites.cy.ts
+++ b/pkg/dashboard/frontend/cypress/e2e/websites.cy.ts
@@ -20,17 +20,20 @@ describe('Websites Spec', () => {
       cy.get(`[data-rct-item-id="${id}"]`).click()
       cy.get('h2').should('contain.text', id)
 
-      const pathMap = {
-        'vite-website': '',
-        'docs-website': 'docs',
+      const originMap = {
+        'vite-website': 'http://localhost:5000',
+        'docs-website': 'http://localhost:5001',
       }
 
-      const url = `http://localhost:5000/${pathMap[id]}`
+      const pathMap = {
+        'vite-website': '/',
+        'docs-website': '/docs',
+      }
 
       // check iframe url
-      cy.get('iframe').should('have.attr', 'src', url)
+      cy.get('iframe').should('have.attr', 'src', originMap[id] + pathMap[id])
 
-      cy.visit(url)
+      cy.visit(originMap[id] + pathMap[id])
 
       const titleMap = {
         'vite-website': 'Hello Nitric!',
@@ -39,7 +42,7 @@ describe('Websites Spec', () => {
 
       const title = titleMap[id]
 
-      cy.origin('http://localhost:5000', { args: { title } }, ({ title }) => {
+      cy.origin(originMap[id], { args: { title } }, ({ title }) => {
         cy.get('h1').should('have.text', title)
       })
     })

--- a/pkg/dashboard/frontend/cypress/e2e/websites.cy.ts
+++ b/pkg/dashboard/frontend/cypress/e2e/websites.cy.ts
@@ -20,9 +20,18 @@ describe('Websites Spec', () => {
       cy.get(`[data-rct-item-id="${id}"]`).click()
       cy.get('h2').should('contain.text', id)
 
-      const originMap = {
-        'vite-website': 'http://localhost:5000',
-        'docs-website': 'http://localhost:5001',
+      let originMap = {}
+
+      if (Cypress.env('NITRIC_TEST_TYPE') === 'run') {
+        originMap = {
+          'vite-website': 'http://localhost:5000',
+          'docs-website': 'http://localhost:5000',
+        }
+      } else {
+        originMap = {
+          'vite-website': 'http://localhost:5000',
+          'docs-website': 'http://localhost:5001',
+        }
       }
 
       const pathMap = {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -827,7 +827,7 @@ func fromProjectConfiguration(projectConfig *ProjectConfiguration, localConfig *
 		}
 
 		if websiteSpec.ErrorPage == "" {
-			websiteSpec.ErrorPage = "index.html"
+			websiteSpec.ErrorPage = "404.html"
 		} else if !strings.HasSuffix(websiteSpec.ErrorPage, ".html") {
 			return nil, fmt.Errorf("invalid error page %s, must end with .html", websiteSpec.ErrorPage)
 		}


### PR DESCRIPTION
Ensures websites function correctly in both `nitric start` and `nitric run` modes.

Introduces separate servers for each website when using `nitric start`, allowing them to run on individual ports. This resolves issues where websites were not being served correctly in development environments.

For static serving (`nitric run`), it uses a single server with a shared port for all websites.

Also, correctly strips the base path from the request URL when proxying requests to the target URL.