### PR TITLE
fix: allow tool to be provided as a flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ nitric new --help
 
 Documentation for all available commands:
 
+- nitric add : Add new resources to your Nitric project
+- nitric add stack [stackName] [providerName] : Create a new Nitric stack
+- nitric add website [websiteName] [toolName] : Add a new website to your Nitric project
 - nitric build : Build a Nitric project
 - nitric debug : Debug Operations (utilities for debugging nitric applications)
 - nitric debug spec : Output the nitric application cloud spec.

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"fmt"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
@@ -77,7 +76,7 @@ nitric add website my-site astro`,
 		})
 		tui.CheckErr(err)
 
-		if _, err := teax.NewProgram(websiteModel, tea.WithANSICompressor()).Run(); err != nil {
+		if _, err := teax.NewProgram(websiteModel).Run(); err != nil {
 			return err
 		}
 

--- a/pkg/view/tui/commands/website/new.go
+++ b/pkg/view/tui/commands/website/new.go
@@ -184,7 +184,9 @@ func New(fs afero.Fs, args Args) (Model, error) {
 		pathPrompt.SetValue(args.WebsitePath)
 		pathPrompt.Blur()
 
-		step = StepTool
+		if args.WebsiteName != "" {
+			step = StepTool
+		}
 	}
 
 	toolItems := []list.ListItem{}
@@ -205,16 +207,6 @@ func New(fs afero.Fs, args Args) (Model, error) {
 		}
 
 		toolPrompt.SetChoice(tool.Name)
-
-		if args.WebsitePath != "" {
-			if !tool.SkipPackageManagerPrompt {
-				step = StepPackageManager
-			} else {
-				step = StepTool
-			}
-		} else {
-			step = StepPath
-		}
 	}
 
 	portValidator := validation.ComposeValidators(PortValidators()...)

--- a/pkg/view/tui/commands/website/new.go
+++ b/pkg/view/tui/commands/website/new.go
@@ -177,6 +177,7 @@ func New(fs afero.Fs, args Args) (Model, error) {
 		if pathInUse {
 			return Model{}, fmt.Errorf("path %s is already in use", args.WebsitePath)
 		}
+
 		if err := pathValidator(args.WebsitePath); err != nil {
 			return Model{}, fmt.Errorf("path %s is invalid: %w", args.WebsitePath, err)
 		}


### PR DESCRIPTION
fixes an issue where providing the tool name with a fresh project (no websites) would freeze the cli.